### PR TITLE
feat: add an endpoint to list models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - input multiplicity within the cli in debug mode
+- `list_model` to the SDK client
 
 ### Removed
 

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -2,7 +2,7 @@
 
 # Client
 ```text
-Client(url: Union[str, NoneType] = None, token: Union[str, NoneType] = None, retry_timeout: int = 300, insecure: bool = False, debug: bool = False)
+Client(url: Optional[str] = None, token: Optional[str] = None, retry_timeout: int = 300, insecure: bool = False, debug: bool = False)
 ```
 
 Create a client
@@ -384,7 +384,7 @@ algorithm.
  - `pathlib.Path`: Path of the downloaded model
 ## from_config_file
 ```text
-from_config_file(profile_name: str = 'default', config_path: Union[str, pathlib.Path] = '~/.substra', tokens_path: Union[str, pathlib.Path] = '~/.substra-tokens', token: Union[str, NoneType] = None, retry_timeout: int = 300, debug: bool = False)
+from_config_file(profile_name: str = 'default', config_path: Union[str, pathlib.Path] = '~/.substra', tokens_path: Union[str, pathlib.Path] = '~/.substra-tokens', token: Optional[str] = None, retry_timeout: int = 300, debug: bool = False)
 ```
 
 Returns a new Client configured with profile data from configuration files.
@@ -712,6 +712,12 @@ The ``filters`` argument is a dictionary, with those possible keys:
 **Returns:**
 
  - `models.Dataset`: the returned object is described
+## list_model
+```text
+list_model(self, filters: dict = None, ascending: bool = False) -> List[substra.sdk.models.OutModel]
+```
+
+List models.
 ## list_organization
 ```text
 list_organization(self, *args, **kwargs) -> List[substra.sdk.models.Organization]

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -718,6 +718,22 @@ list_model(self, filters: dict = None, ascending: bool = False) -> List[substra.
 ```
 
 List models.
+The ``filters`` argument is a dictionnary, with those possible keys:
+
+    key (list[str]): list model with given keys.
+
+    compute_task_key (list[str]): list model produced by this compute task.
+
+    owner (list[str]): list model with given owners.
+
+    permissions (list[str]): list models which can be used by any of the listed nodes. Remote mode only.
+
+**Arguments:**
+ - `filters (dict, optional)`: List of key values pair to filter on. Default None.
+ - `ascending (bool, optional)`: Sorts results by oldest creation_date first. Default False (descending order).
+
+**Returns:**
+models.OutModel the returned object is described in the [models.OutModel](sdk_models.md#OutModel) model
 ## list_organization
 ```text
 list_organization(self, *args, **kwargs) -> List[substra.sdk.models.Organization]

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -266,6 +266,7 @@ class Worker:
                 permissions=task.outputs[algo_output.identifier].permissions,
             )
             task.outputs[algo_output.identifier].value = value
+            self._db.add(value)
 
         else:
             raise ValueError(f"This asset kind is not supported for algo output: {algo_output.kind}")

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -480,7 +480,20 @@ class Client(object):
 
     @logit
     def list_model(self, filters: dict = None, ascending: bool = False) -> List[models.OutModel]:
-        """List models."""
+        """List models.
+
+        The ``filters`` argument is a dictionnary, with those possible keys:\n
+            key (list[str]): list model with given keys.\n
+            compute_task_key (list[str]): list model produced by this compute task.\n
+            owner (list[str]): list model with given owners.\n
+            permissions (list[str]): list models which can be used by any of the listed nodes. Remote mode only.\n
+
+        Args:
+            filters (dict, optional): List of key values pair to filter on. Default None.
+            ascending (bool, optional): Sorts results by oldest creation_date first. Default False (descending order).
+
+        Returns:
+            models.OutModel the returned object is described in the [models.OutModel](sdk_models.md#OutModel) model"""
         return self._list(schemas.Type.Model, filters, "creation_date", ascending)
 
     @logit

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -480,8 +480,7 @@ class Client(object):
 
     @logit
     def list_model(self, filters: dict = None, ascending: bool = False) -> List[models.OutModel]:
-        """List models.
-        """
+        """List models."""
         return self._list(schemas.Type.Model, filters, "creation_date", ascending)
 
     @logit

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -479,6 +479,12 @@ class Client(object):
         return self._backend.get(schemas.Type.Model, key)
 
     @logit
+    def list_model(self, filters: dict = None, ascending: bool = False) -> List[models.OutModel]:
+        """List models.
+        """
+        return self._list(schemas.Type.Model, filters, "creation_date", ascending)
+
+    @logit
     def get_data_sample(self, key: str) -> models.DataSample:
         """Get data sample by key, the returned object is described
         in the [models.Datasample](sdk_models.md#DataSample) model"""

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -246,6 +246,10 @@ class OutModel(schemas._PydanticConfig):
 
     type_: ClassVar[str] = schemas.Type.Model
 
+    @staticmethod
+    def allowed_filters() -> List[str]:
+        return ["key", "compute_task_key", "owner", "permissions"]
+
 
 class InputRef(schemas._PydanticConfig):
     identifier: str

--- a/tests/sdk/test_list.py
+++ b/tests/sdk/test_list.py
@@ -21,6 +21,7 @@ from ..utils import mock_requests
         "composite_traintuple",
         "compute_plan",
         "data_sample",
+        "model",
     ],
 )
 def test_list_asset(asset_type, client, mocker):
@@ -48,6 +49,7 @@ def test_list_asset(asset_type, client, mocker):
         ("composite_traintuple", {"owner": ["foo", "bar"]}),
         ("compute_plan", {"name": "foo"}),
         ("compute_plan", {"status": [models.ComputePlanStatus.done.value]}),
+        ("model", {"owner": ["MyOrg1MSP"]}),
     ],
 )
 def test_list_asset_with_filters(asset_type, filters, client, mocker):


### PR DESCRIPTION
## Summary

Add an endpoint in order to be able to list models and filter the list by compute task key to retrieve the models produced by a task. It is needed because I don't want to use the field `task.<category>.models` as it will be removed soon.
