### PR TITLE
tests: fix algo inputs and task code consistency

### DIFF
--- a/tests/data_factory.py
+++ b/tests/data_factory.py
@@ -17,9 +17,11 @@ from .fl_interface import OutputIdentifiers
 
 DEFAULT_DATA_SAMPLE_FILENAME = "data.csv"
 
-DEFAULT_SUBSTRATOOLS_VERSION = (
-    f"latest-nvidiacuda11.6.0-base-ubuntu20.04-python{sys.version_info.major}.{sys.version_info.minor}-minimal"
-)
+# TODO: change before merge
+DEFAULT_SUBSTRATOOLS_VERSION = "test_gt_amd64-minimal"
+# DEFAULT_SUBSTRATOOLS_VERSION = (
+#     f"latest-nvidiacuda11.6.0-base-ubuntu20.04-python{sys.version_info.major}.{sys.version_info.minor}-minimal"
+# )
 
 DEFAULT_SUBSTRATOOLS_DOCKER_IMAGE = f"ghcr.io/substra/substra-tools:{DEFAULT_SUBSTRATOOLS_VERSION}"
 

--- a/tests/data_factory.py
+++ b/tests/data_factory.py
@@ -17,11 +17,9 @@ from .fl_interface import OutputIdentifiers
 
 DEFAULT_DATA_SAMPLE_FILENAME = "data.csv"
 
-# TODO: change before merge
-DEFAULT_SUBSTRATOOLS_VERSION = "test_gt_amd64-minimal"
-# DEFAULT_SUBSTRATOOLS_VERSION = (
-#     f"latest-nvidiacuda11.6.0-base-ubuntu20.04-python{sys.version_info.major}.{sys.version_info.minor}-minimal"
-# )
+DEFAULT_SUBSTRATOOLS_VERSION = (
+    f"latest-nvidiacuda11.6.0-base-ubuntu20.04-python{sys.version_info.major}.{sys.version_info.minor}-minimal"
+)
 
 DEFAULT_SUBSTRATOOLS_DOCKER_IMAGE = f"ghcr.io/substra/substra-tools:{DEFAULT_SUBSTRATOOLS_VERSION}"
 

--- a/tests/fl_interface.py
+++ b/tests/fl_interface.py
@@ -74,7 +74,7 @@ class FLAlgoInputs(list, Enum):
         AlgoInputSpec(
             identifier=InputIdentifiers.opener, kind=AssetKind.data_manager.value, optional=False, multiple=False
         ),
-        AlgoInputSpec(identifier=InputIdentifiers.models, kind=AssetKind.model.value, optional=False, multiple=False),
+        AlgoInputSpec(identifier=InputIdentifiers.model, kind=AssetKind.model.value, optional=False, multiple=False),
     ]
     ALGO_PREDICT_COMPOSITE = [
         AlgoInputSpec(
@@ -170,7 +170,7 @@ class FLTaskInputGenerator:
     def train_to_predict(model_key):
         return [
             InputRef(
-                identifier=InputIdentifiers.models,
+                identifier=InputIdentifiers.model,
                 parent_task_key=model_key,
                 parent_task_output_identifier=OutputIdentifiers.model,
             )


### PR DESCRIPTION
Companion PRs: 
- substra tools: https://github.com/Substra/substra-tools/pull/49 (main)
- substra-test: https://github.com/Substra/substra-tests/pull/200
- substra: https://github.com/Substra/substra/pull/278 (here)

e2e tests: https://github.com/owkin/connect-ci/actions/runs/3051066299/jobs/4918859354

there is an inconsistency between the declared input for predict task and the one generated per connect-tools.
As substra-tools consumes the inputs and outputs with the companion RP, I added the fix to this batch.

The other solution would have been to do a separate batch to fix this issue in addition (longer and useless IMO).

About how to run the tests please check substra-tools companion PR