### PR TITLE
feat: set the default batch size to 400 to make the compute plan submission faster

### DIFF
--- a/substra/__version__.py
+++ b/substra/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.29.1"
+__version__ = "0.29.2"

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -33,7 +33,7 @@ from substra.sdk.utils import is_valid_uuid
 logger = logging.getLogger(__name__)
 
 DEFAULT_RETRY_TIMEOUT = 5 * 60
-DEFAULT_BATCH_SIZE = 500
+DEFAULT_BATCH_SIZE = 400
 
 
 def logit(f):

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -33,7 +33,7 @@ from substra.sdk.utils import is_valid_uuid
 logger = logging.getLogger(__name__)
 
 DEFAULT_RETRY_TIMEOUT = 5 * 60
-DEFAULT_BATCH_SIZE = 20
+DEFAULT_BATCH_SIZE = 500
 
 
 def logit(f):


### PR DESCRIPTION
Patch - include the default batch size update from this commit: https://github.com/Substra/substra/commit/4d9233b000fc34bc64f58b7e3823d66c5aed3fd9
into the release 0.29.2

--> Changing it to 400 as we get timeouts with 450

EDIT: the question is actually more complex than that, discussing it in an issue here: https://github.com/Substra/substra/issues/282