### PR TITLE
chore!: remove clean_models flag on compute plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `schemas.ComputePlanSpec` `clean_models` property is now deprecated, the transient property on tasks outputs should be used instead.
+
 ## [0.36.0](https://github.com/Substra/substra/releases/tag/0.36.0) - 2022-09-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- `schemas.ComputePlanSpec` `clean_models` property is now deprecated, the transient property on tasks outputs should be used instead.
+- BREAKING CHANGE: `schemas.ComputePlanSpec` `clean_models` property is now removed, the transient property on tasks outputs should be used instead.
 
 ## [0.36.0](https://github.com/Substra/substra/releases/tag/0.36.0) - 2022-09-12
 

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import os
 import shutil
-import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Dict
@@ -396,8 +395,6 @@ class Local(base.BaseBackend):
         return data_samples
 
     def _add_compute_plan(self, spec: schemas.ComputePlanSpec, spec_options: dict = None):
-        if spec.clean_models:
-            warnings.warn("'clean_models=True' is ignored on the local backend.")
         self._check_metadata(spec.metadata)
         # Get all the tuples and their dependencies
         tuple_graph, tuples = compute_plan_module.get_dependency_graph(spec)
@@ -421,7 +418,6 @@ class Local(base.BaseBackend):
             failed_count=0,
             done_count=0,
             owner=self._org_id,
-            delete_intermediary_models=spec.clean_models if spec.clean_models is not None else False,
         )
         compute_plan = self._db.add(compute_plan)
 

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -419,7 +419,6 @@ class ComputePlan(_Model):
     failed_count: int = 0
     done_count: int = 0
     failed_task: Optional[FailedTuple]
-    delete_intermediary_models: bool = False
     status: ComputePlanStatus
     creation_date: datetime
     start_date: Optional[datetime]

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -7,8 +7,10 @@ import uuid
 from typing import Dict
 from typing import List
 from typing import Optional
+import warnings
 
 import pydantic
+from pydantic.class_validators import validator
 from pydantic.fields import Field
 
 from substra.sdk import utils
@@ -297,6 +299,12 @@ class ComputePlanSpec(_BaseComputePlanSpec):
         data = json.loads(self.json(exclude_unset=True))
         data["key"] = self.key
         yield data, None
+
+    @validator("clean_models")
+    def deprecation_validator(cls, v):
+       warnings.warn("clean_models field is deprecated, use task outputs transient property instead", DeprecationWarning) 
+       return v
+        
 
 
 class UpdateComputePlanTuplesSpec(_BaseComputePlanSpec):

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -4,13 +4,11 @@ import json
 import pathlib
 import typing
 import uuid
-import warnings
 from typing import Dict
 from typing import List
 from typing import Optional
 
 import pydantic
-from pydantic.class_validators import validator
 from pydantic.fields import Field
 
 from substra.sdk import utils
@@ -287,7 +285,6 @@ class ComputePlanSpec(_BaseComputePlanSpec):
     key: str = pydantic.Field(default_factory=lambda: str(uuid.uuid4()))
     tag: Optional[str]
     name: str
-    clean_models: Optional[bool]
     metadata: Optional[Dict[str, str]]
 
     type_: typing.ClassVar[Type] = Type.ComputePlan
@@ -299,13 +296,6 @@ class ComputePlanSpec(_BaseComputePlanSpec):
         data = json.loads(self.json(exclude_unset=True))
         data["key"] = self.key
         yield data, None
-
-    @validator("clean_models")
-    def deprecation_validator(cls, v):
-        warnings.warn(
-            "clean_models field is deprecated, use task outputs transient property instead", DeprecationWarning
-        )
-        return v
 
 
 class UpdateComputePlanTuplesSpec(_BaseComputePlanSpec):

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -4,10 +4,10 @@ import json
 import pathlib
 import typing
 import uuid
+import warnings
 from typing import Dict
 from typing import List
 from typing import Optional
-import warnings
 
 import pydantic
 from pydantic.class_validators import validator
@@ -302,9 +302,10 @@ class ComputePlanSpec(_BaseComputePlanSpec):
 
     @validator("clean_models")
     def deprecation_validator(cls, v):
-       warnings.warn("clean_models field is deprecated, use task outputs transient property instead", DeprecationWarning) 
-       return v
-        
+        warnings.warn(
+            "clean_models field is deprecated, use task outputs transient property instead", DeprecationWarning
+        )
+        return v
 
 
 class UpdateComputePlanTuplesSpec(_BaseComputePlanSpec):

--- a/tests/data_factory.py
+++ b/tests/data_factory.py
@@ -429,7 +429,7 @@ class AssetsFactory:
             metadata=metadata,
         )
 
-    def create_compute_plan(self, key=None, tag="", name="Test compute plan", clean_models=False, metadata=None):
+    def create_compute_plan(self, key=None, tag="", name="Test compute plan", metadata=None):
         return substra.sdk.schemas.ComputePlanSpec(
             key=key or random_uuid(),
             traintuples=[],
@@ -440,7 +440,6 @@ class AssetsFactory:
             tag=tag,
             name=name,
             metadata=metadata,
-            clean_models=clean_models,
         )
 
     def add_compute_plan_tuples(self, compute_plan):

--- a/tests/sdk/local/test_debug.py
+++ b/tests/sdk/local/test_debug.py
@@ -76,7 +76,6 @@ class TestsDebug:
                 key=str(uuid.uuid4()),
                 tag=None,
                 name="My ultra cool compute plan",
-                clean_models=False,
                 metadata=dict(),
             )
         )
@@ -134,7 +133,6 @@ class TestsDebug:
                 key=str(uuid.uuid4()),
                 tag="cool-tag",
                 name=old_name,
-                clean_models=False,
                 metadata=dict(),
             )
         )
@@ -310,7 +308,6 @@ class TestsDebug:
                 key=common_cp_key,
                 tag=None,
                 name="My compute plan",
-                clean_models=False,
                 metadata=dict(),
             )
         )
@@ -320,7 +317,6 @@ class TestsDebug:
                     key=common_cp_key,
                     tag=None,
                     name="My other compute plan",
-                    clean_models=False,
                     metadata=dict(),
                 )
             )


### PR DESCRIPTION
## Summary

The `clean_models` is now removed as users should use the `transient` flag on tasks outputs instead.

## Notes

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [x] [substra-tests](https://github.com/Substra/substra)
  - [x] [substrafl](https://github.com/Substra/substrafl)
  - [x] [substra-documentation](https://github.com/Substra/substra-documentation)
