### PR TITLE
feat: stop checking algo category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ tests: fix algo inputs and task code consistency
 ### Changed
 
 - BREAKING CHANGE: `schemas.ComputePlanSpec` `clean_models` property is now removed, the transient property on tasks outputs should be used instead.
+- Algo categories are not checked anymore in local mode. Validations based on inputs and outputs are sufficient.
 
 ## [0.36.0](https://github.com/Substra/substra/releases/tag/0.36.0) - 2022-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Algo categories are not checked anymore in local mode. Validations based on inputs and outputs are sufficient.
+
 ## [0.37.0](https://github.com/Substra/substra/releases/tag/0.37.0) - 2022-09-19
 
 ### Fixed
@@ -16,7 +20,6 @@ tests: fix algo inputs and task code consistency
 ### Changed
 
 - BREAKING CHANGE: `schemas.ComputePlanSpec` `clean_models` property is now removed, the transient property on tasks outputs should be used instead.
-- Algo categories are not checked anymore in local mode. Validations based on inputs and outputs are sufficient.
 
 ## [0.36.0](https://github.com/Substra/substra/releases/tag/0.36.0) - 2022-09-12
 

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -199,7 +199,6 @@ ComputePlan
 - failed_count: int
 - done_count: int
 - failed_task: Optional[FailedTuple]
-- delete_intermediary_models: bool
 - status: ComputePlanStatus
 - creation_date: datetime
 - start_date: Optional[datetime]

--- a/references/sdk_schemas.md
+++ b/references/sdk_schemas.md
@@ -185,7 +185,6 @@ Specification for creating a compute plan
 - testtuples: Optional[List[ComputePlanTesttupleSpec]]
 - tag: Optional[str]
 - name: str
-- clean_models: Optional[bool]
 - metadata: Optional[Mapping[str, str]]
 ```
 

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -433,7 +433,6 @@ class Local(base.BaseBackend):
         self._check_metadata(spec.metadata)
 
         algo = self._db.get(schemas.Type.Algo, spec.algo_key)
-        assert algo.category == schemas.AlgoCategory.simple
 
         dataset = self._db.get(schemas.Type.Dataset, spec.data_manager_key)
         in_tuples = []
@@ -604,7 +603,6 @@ class Local(base.BaseBackend):
         # validation
         self._check_metadata(spec.metadata)
         algo = self._db.get(schemas.Type.Algo, spec.algo_key)
-        assert algo.category == schemas.AlgoCategory.composite
         dataset = self._db.get(schemas.Type.Dataset, spec.data_manager_key)
         self.__check_data_samples(
             data_manager_key=spec.data_manager_key, data_sample_keys=spec.train_data_sample_keys, allow_test_only=False
@@ -669,7 +667,6 @@ class Local(base.BaseBackend):
         # validation
         self._check_metadata(spec.metadata)
         algo = self._db.get(schemas.Type.Algo, spec.algo_key)
-        assert algo.category == schemas.AlgoCategory.aggregate
 
         in_tuples = list()
         for in_tuple_key in spec.in_models_keys:


### PR DESCRIPTION
## Summary

Do not rely on Algo categories for validation since they are deprecated.

## Notes

Related:
- https://github.com/Substra/orchestrator/pull/24
- https://github.com/Substra/substra-backend/pull/460

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [x] [substra-tests](https://github.com/Substra/substra)
  - [x] [substrafl](https://github.com/Substra/substrafl)
  - [x] [substra-documentation](https://github.com/Substra/substra-documentation)
