### PR TITLE
feat: prevent use of '__' in asset metadata keys in local mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Prevent use of `__` in asset metadata keys in local mode
+
 ## [0.38.0](https://github.com/Substra/substra/releases/tag/0.38.0) - 2022-09-26
 
 ### Tests

--- a/references/sdk_schemas.md
+++ b/references/sdk_schemas.md
@@ -39,6 +39,8 @@ the 'paths' field.
 
 ## DatasetSpec
 Specification for creating a dataset
+
+note : metadata field does not accept strings containing '__' as dict key
 ```text
 - name: str
 - data_opener: Path
@@ -57,6 +59,8 @@ Specification for updating a dataset
 
 ## AlgoSpec
 Specification for creating an algo
+
+note : metadata field does not accept strings containing '__' as dict key
 ```text
 - name: str
 - description: Path
@@ -87,6 +91,8 @@ Asset creation specification base class.
 
 ## PredicttupleSpec
 Specification for creating a predict tuple
+
+note : metadata field does not accept strings containing '__' as dict key
 ```text
 - key: str
 - tag: Optional[str]
@@ -109,6 +115,8 @@ Specification for updating an algo
 
 ## TesttupleSpec
 Specification for creating a testtuple
+
+note : metadata field does not accept strings containing '__' as dict key
 ```text
 - key: str
 - tag: Optional[str]
@@ -125,6 +133,8 @@ Specification for creating a testtuple
 
 ## TraintupleSpec
 Specification for creating a traintuple
+
+note : metadata field does not accept strings containing '__' as dict key
 ```text
 - key: str
 - tag: Optional[str]
@@ -142,6 +152,8 @@ Specification for creating a traintuple
 
 ## AggregatetupleSpec
 Specification for creating an aggregate tuple
+
+note : metadata field does not accept strings containing '__' as dict key
 ```text
 - key: str
 - tag: Optional[str]
@@ -158,6 +170,8 @@ Specification for creating an aggregate tuple
 
 ## CompositeTraintupleSpec
 Specification for creating a composite traintuple
+
+note : metadata field does not accept strings containing '__' as dict key
 ```text
 - key: str
 - tag: Optional[str]
@@ -176,6 +190,8 @@ Specification for creating a composite traintuple
 
 ## ComputePlanSpec
 Specification for creating a compute plan
+
+note : metadata field does not accept strings containing '__' as dict key
 ```text
 - key: str
 - traintuples: Optional[List[ComputePlanTraintupleSpec]]

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -155,7 +155,7 @@ class Local(base.BaseBackend):
                 raise exceptions.InvalidRequest("Values in metadata cannot be empty or more than 100 characters", 400)
             if any("__" in key for key in metadata):
                 raise exceptions.InvalidRequest(
-                    '"__" cannot be used in a metadata key, please use simple underscore instead'
+                    '"__" cannot be used in a metadata key, please use simple underscore instead', 400
                 )
 
     def __compute_permissions(self, permissions):

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -153,6 +153,10 @@ class Local(base.BaseBackend):
                 raise exceptions.InvalidRequest("The key in metadata cannot be more than 50 characters", 400)
             if any([len(value) > _MAX_LEN_VALUE_METADATA or len(value) == 0 for value in metadata.values()]):
                 raise exceptions.InvalidRequest("Values in metadata cannot be empty or more than 100 characters", 400)
+            if any("__" in key for key in metadata):
+                raise exceptions.InvalidRequest(
+                    '"__" cannot be used in a metadata key, please use simple underscore instead'
+                )
 
     def __compute_permissions(self, permissions):
         """Compute the permissions

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -218,7 +218,10 @@ class ComputeTaskOutputSpec(_PydanticConfig):
 
 
 class _ComputePlanComputeTaskSpec(_Spec):
-    """Specification of a compute task inside a compute plan specification"""
+    """Specification of a compute task inside a compute plan specification
+
+    note : metadata field does not accept strings containing '__' as dict key
+    """
 
     algo_key: str
     tag: Optional[str]
@@ -286,7 +289,10 @@ class _BaseComputePlanSpec(_Spec):
 
 
 class ComputePlanSpec(_BaseComputePlanSpec):
-    """Specification for creating a compute plan"""
+    """Specification for creating a compute plan
+
+    note : metadata field does not accept strings containing '__' as dict key
+    """
 
     key: str = pydantic.Field(default_factory=lambda: str(uuid.uuid4()))
     tag: Optional[str]
@@ -319,7 +325,10 @@ class UpdateComputePlanSpec(_Spec):
 
 
 class DatasetSpec(_Spec):
-    """Specification for creating a dataset"""
+    """Specification for creating a dataset
+
+    note : metadata field does not accept strings containing '__' as dict key
+    """
 
     name: str
     data_opener: pathlib.Path  # Path to the data opener
@@ -397,7 +406,10 @@ class AlgoOutputSpec(_Spec):
 
 
 class AlgoSpec(_Spec):
-    """Specification for creating an algo"""
+    """Specification for creating an algo
+
+    note : metadata field does not accept strings containing '__' as dict key
+    """
 
     name: str
     description: pathlib.Path
@@ -468,7 +480,10 @@ class _TupleSpec(_Spec):
 
 
 class TraintupleSpec(_TupleSpec):
-    """Specification for creating a traintuple"""
+    """Specification for creating a traintuple
+
+    note : metadata field does not accept strings containing '__' as dict key
+    """
 
     data_manager_key: str
     train_data_sample_keys: List[str]
@@ -497,7 +512,10 @@ class TraintupleSpec(_TupleSpec):
 
 
 class AggregatetupleSpec(_TupleSpec):
-    """Specification for creating an aggregate tuple"""
+    """Specification for creating an aggregate tuple
+
+    note : metadata field does not accept strings containing '__' as dict key
+    """
 
     worker: str
     in_models_keys: List[str]
@@ -526,7 +544,10 @@ class AggregatetupleSpec(_TupleSpec):
 
 
 class CompositeTraintupleSpec(_TupleSpec):
-    """Specification for creating a composite traintuple"""
+    """Specification for creating a composite traintuple
+
+    note : metadata field does not accept strings containing '__' as dict key
+    """
 
     data_manager_key: str
     train_data_sample_keys: List[str]
@@ -559,7 +580,10 @@ class CompositeTraintupleSpec(_TupleSpec):
 
 
 class PredicttupleSpec(_TupleSpec):
-    """Specification for creating a predict tuple"""
+    """Specification for creating a predict tuple
+
+    note : metadata field does not accept strings containing '__' as dict key
+    """
 
     traintuple_key: str
     data_manager_key: str
@@ -589,7 +613,10 @@ class PredicttupleSpec(_TupleSpec):
 
 
 class TesttupleSpec(_TupleSpec):
-    """Specification for creating a testtuple"""
+    """Specification for creating a testtuple
+
+    note : metadata field does not accept strings containing '__' as dict key
+    """
 
     predicttuple_key: str
     data_manager_key: str

--- a/tests/sdk/local/test_debug.py
+++ b/tests/sdk/local/test_debug.py
@@ -324,6 +324,19 @@ class TestsDebug:
                 )
             )
 
+    def test_add_compute_plan_with_wrong_metadata(self, clients):
+        client = clients[0]
+        cp_key = str(uuid.uuid4())
+        with pytest.raises(InvalidRequest):
+            client.add_compute_plan(
+                substra.sdk.schemas.ComputePlanSpec(
+                    key=cp_key,
+                    tag=None,
+                    name="My compute plan",
+                    metadata={"wrong__key": "value"},
+                )
+            )
+
     def test_live_performances_json_file_exist(self, asset_factory, clients):
         """Assert the performances file is well created."""
         client = clients[0]


### PR DESCRIPTION
## Related issue

See [PR description](https://github.com/Substra/substra-backend/pull/468) for more details

## Summary

The remote backend prevents now the use of `__` in asset metadata keys, to keep filtering feature on metadata fully functionnal.
Even though it's not an issue in local mode, allowing different naming in local and remote mode should be avoided, this PR prevents use of `__` in asset metadata keys in local mode as well.

## Notes

Companion PR : 
- https://github.com/Substra/substra-backend/pull/468

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [x] [substra-tests](https://github.com/Substra/substra) - https://github.com/Substra/substra-tests/pull/212
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
