### PR TITLE
chore: bump substra-tools version to v0.18.0 in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ API after
 client = substra.Client(backend_type=substra.BackendType.LOCAL_SUBPROCESS)
 ```
 - Pass substra-tools arguments via a file instead of the command line
+- Python package depends on substra-tools v0.18.0
 
 ### Removed
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
             "pytest",
             "pytest-cov",
             "pytest-mock",
-            "substratools>=0.17.0",
+            "substratools>=0.18.0",
             "black",
             "flake8",
             "isort",


### PR DESCRIPTION
Follow-up to https://github.com/Substra/substra-tools/pull/61