### PR TITLE
remove: algo category from schemas and models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- BREAKING CHANGE: remove category from substra.schema.AlgoSpec and substra.models.Algo
+
 ### Added
 
 - Prevent use of `__` in asset metadata keys in local mode

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -175,7 +175,6 @@ Asset creation specification base class.
 - owner: str
 - permissions: Permissions
 - metadata: Mapping[str, str]
-- category: AlgoCategory
 - creation_date: datetime
 - inputs: List[AlgoInput]
 - outputs: List[AlgoOutput]

--- a/references/sdk_schemas.md
+++ b/references/sdk_schemas.md
@@ -67,7 +67,6 @@ note : metadata field does not accept strings containing '__' as dict key
 - file: Path
 - permissions: Permissions
 - metadata: Optional[Mapping[str, str]]
-- category: AlgoCategory
 - inputs: Optional[List[AlgoInputSpec]]
 - outputs: Optional[List[AlgoOutputSpec]]
 ```

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -297,7 +297,6 @@ class Local(base.BaseBackend):
             creation_date=self.__now(),
             name=spec.name,
             owner=self._org_id,
-            category=spec.category,
             permissions={
                 "process": {
                     "public": permissions.public,

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -175,7 +175,6 @@ class Algo(_Model):
     owner: str
     permissions: Permissions
     metadata: Dict[str, str]
-    category: schemas.AlgoCategory
     creation_date: datetime
     inputs: List[AlgoInput]
     outputs: List[AlgoOutput]

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -67,17 +67,6 @@ class Type(enum.Enum):
         return self.name
 
 
-class AlgoCategory(str, enum.Enum):
-    """Algo category"""
-
-    unknown = "ALGO_UNKNOWN"
-    simple = "ALGO_SIMPLE"
-    composite = "ALGO_COMPOSITE"
-    aggregate = "ALGO_AGGREGATE"
-    metric = "ALGO_METRIC"
-    predict = "ALGO_PREDICT"
-
-
 class TaskCategory(str, enum.Enum):
     """Task category"""
 

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -416,7 +416,6 @@ class AlgoSpec(_Spec):
     file: pathlib.Path
     permissions: Permissions
     metadata: Optional[Dict[str, str]]
-    category: AlgoCategory
     inputs: Optional[List[AlgoInputSpec]] = None
     outputs: Optional[List[AlgoOutputSpec]] = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,6 @@ def algo_query(tmpdir):
 
     return AlgoSpec(
         name="algo_name",
-        category=algo_category,
         inputs=FLAlgoInputs[algo_category],
         outputs=FLAlgoOutputs[algo_category],
         description=str(desc_path),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from substra.sdk.schemas import AlgoSpec
 from . import data_factory
 from .fl_interface import FLAlgoInputs
 from .fl_interface import FLAlgoOutputs
+from .fl_interface import AlgoCategory
 
 
 def pytest_configure(config):
@@ -79,7 +80,7 @@ def algo_query(tmpdir):
     desc_path = tmpdir / "description.md"
     desc_path.write_text("#Hello world", encoding="utf-8")
 
-    algo_category = substra.sdk.schemas.AlgoCategory.simple
+    algo_category = AlgoCategory.simple
 
     return AlgoSpec(
         name="algo_name",

--- a/tests/data_factory.py
+++ b/tests/data_factory.py
@@ -405,12 +405,8 @@ class AssetsFactory:
             ),
         )
 
-        spec_category = category
-        if category == FL_ALGO_PREDICT_COMPOSITE:
-            spec_category = substra.schemas.AlgoCategory.predict
         return substra.sdk.schemas.AlgoSpec(
             name=name,
-            category=spec_category,
             inputs=FLAlgoInputs[category],
             outputs=FLAlgoOutputs[category],
             description=str(description_path),

--- a/tests/data_factory.py
+++ b/tests/data_factory.py
@@ -7,9 +7,8 @@ import uuid
 import zipfile
 
 import substra
-from substra.sdk.schemas import AlgoCategory
 
-from .fl_interface import FL_ALGO_PREDICT_COMPOSITE
+from .fl_interface import AlgoCategory
 from .fl_interface import FLAlgoInputs
 from .fl_interface import FLAlgoOutputs
 from .fl_interface import InputIdentifiers
@@ -226,7 +225,7 @@ DEFAULT_ALGO_SCRIPTS = {
     AlgoCategory.aggregate: DEFAULT_AGGREGATE_ALGO_SCRIPT,
     AlgoCategory.predict: DEFAULT_ALGO_SCRIPT,
     AlgoCategory.metric: DEFAULT_METRIC_ALGO_SCRIPT,
-    FL_ALGO_PREDICT_COMPOSITE: DEFAULT_COMPOSITE_ALGO_SCRIPT,
+    AlgoCategory.predict_composite: DEFAULT_COMPOSITE_ALGO_SCRIPT,
 }
 
 DEFAULT_ALGO_METHOD_NAME = {
@@ -235,7 +234,7 @@ DEFAULT_ALGO_METHOD_NAME = {
     AlgoCategory.aggregate: "aggregate",
     AlgoCategory.predict: "predict",
     AlgoCategory.metric: "score",
-    FL_ALGO_PREDICT_COMPOSITE: "predict",
+    AlgoCategory.predict_composite: "predict",
 }
 
 DEFAULT_ALGO_DOCKERFILE = f"""

--- a/tests/fl_interface.py
+++ b/tests/fl_interface.py
@@ -9,7 +9,17 @@ from substra.sdk.schemas import Permissions
 
 PUBLIC_PERMISSIONS = Permissions(public=True, authorized_ids=[])
 
-FL_ALGO_PREDICT_COMPOSITE = "ALGO_PREDICT_COMPOSITE"
+
+class AlgoCategory(str, Enum):
+    """Algo category"""
+
+    unknown = "ALGO_UNKNOWN"
+    simple = "ALGO_SIMPLE"
+    composite = "ALGO_COMPOSITE"
+    aggregate = "ALGO_AGGREGATE"
+    metric = "ALGO_METRIC"
+    predict = "ALGO_PREDICT"
+    predict_composite = "ALGO_PREDICT_COMPOSITE"
 
 
 class InputIdentifiers(str, Enum):

--- a/tests/sdk/local/test_debug.py
+++ b/tests/sdk/local/test_debug.py
@@ -8,11 +8,10 @@ import substra
 from substra.sdk import models
 from substra.sdk.exceptions import InvalidRequest
 from substra.sdk.exceptions import KeyAlreadyExistsError
-from substra.sdk.schemas import AlgoCategory
 
-from ...fl_interface import FL_ALGO_PREDICT_COMPOSITE
 from ...fl_interface import FLTaskInputGenerator
 from ...fl_interface import FLTaskOutputGenerator
+from ...fl_interface import AlgoCategory
 
 
 def test_wrong_debug_spawner():
@@ -573,7 +572,7 @@ def test_two_composite_to_composite(asset_factory, subprocess_clients):
     algo_query = asset_factory.create_algo(AlgoCategory.composite)
     algo_key = client.add_algo(algo_query)
 
-    predict_algo_spec = asset_factory.create_algo(category=FL_ALGO_PREDICT_COMPOSITE)
+    predict_algo_spec = asset_factory.create_algo(category=AlgoCategory.predict_composite)
     predict_algo_key = client.add_algo(predict_algo_spec)
 
     metric = asset_factory.create_algo(category=AlgoCategory.metric)


### PR DESCRIPTION
Signed-off-by: Louis Hulot <louis.hulot@owkin.com>

Companion PRs:
substra-tests: https://github.com/Substra/substra-tests/pull/219 
substrafl: https://github.com/Substra/substrafl/pull/29
substra: https://github.com/Substra/substra/pull/294 (main) (here)
documentation: https://github.com/Substra/substra-documentation/pull/186
orchestrator: https://github.com/Substra/orchestrator/pull/42
backend: https://github.com/Substra/substra-backend/pull/487 


## Related issue

`#` followed by the number of the issue

## Summary

Remove AlgoCategory from substra. 
As the test are based on AlgoCategory I put the class within the fl_interface

## Notes

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
