### PR TITLE
feat: docker: add build logs to container image build exception messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- docker: add build logs to container image build exception messages
+
 ## [0.38.0](https://github.com/Substra/substra/releases/tag/0.38.0) - 2022-09-26
 
 ### Tests

--- a/substra/sdk/backends/local/compute/spawner/base.py
+++ b/substra/sdk/backends/local/compute/spawner/base.py
@@ -8,7 +8,15 @@ VOLUME_INPUTS = "_VOLUME_INPUTS"
 VOLUME_OUTPUTS = "_VOLUME_OUTPUTS"
 
 
+class BuildError(Exception):
+    """An error occurred during the build of the algo"""
+
+    pass
+
+
 class ExecutionError(Exception):
+    """An error occurred during the execution of the compute task"""
+
     pass
 
 

--- a/substra/sdk/backends/local/compute/spawner/docker.py
+++ b/substra/sdk/backends/local/compute/spawner/docker.py
@@ -12,6 +12,7 @@ from substra.sdk.backends.local.compute.spawner.base import VOLUME_CLI_ARGS
 from substra.sdk.backends.local.compute.spawner.base import VOLUME_INPUTS
 from substra.sdk.backends.local.compute.spawner.base import VOLUME_OUTPUTS
 from substra.sdk.backends.local.compute.spawner.base import BaseSpawner
+from substra.sdk.backends.local.compute.spawner.base import BuildError
 from substra.sdk.backends.local.compute.spawner.base import ExecutionError
 from substra.sdk.backends.local.compute.spawner.base import write_command_args_file
 
@@ -78,10 +79,12 @@ class Docker(BaseSpawner):
                     uncompress(archive_path, tmpdir)
                     self._docker.images.build(path=tmpdir, tag=name, rm=True)
                 except docker.errors.BuildError as exc:
+                    log = ""
                     for line in exc.build_log:
                         if "stream" in line:
-                            logger.error(line["stream"].strip())
-                    raise
+                            log += line["stream"].strip()
+                    logger.error(log)
+                    raise BuildError(log)
 
     def spawn(
         self,


### PR DESCRIPTION
Companion PRs:
- https://github.com/Substra/substra-backend/pull/483 (main PR)
- https://github.com/Substra/orchestrator/pull/38
- https://github.com/Substra/substra/pull/295 (this PR)
- https://github.com/Substra/substra-tests/pull/218
- https://github.com/Substra/substra-frontend/pull/116
- https://github.com/Substra/substra-documentation/pull/184

--- 

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
