### PR TITLE
Patch/0.29.2

### DIFF
--- a/substra/__version__.py
+++ b/substra/__version__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.29.1"
+__version__ = "0.29.2"

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -223,7 +223,7 @@ class Remote(base.BaseBackend):
             try:
                 self._add_tuples(batch, spec_options)
             except exceptions.AlreadyExists:
-                logger.info(
+                logger.warning(
                     "Skipping already submitted tasks, probably because of a timeout error. "
                     "Check that the compute plan has the right number of tasks once the submission is complete."
                 )

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -220,7 +220,14 @@ class Remote(base.BaseBackend):
             batches = [tuples]
 
         for batch in batches:
-            self._add_tuples(batch, spec_options)
+            try:
+                self._add_tuples(batch, spec_options)
+            except exceptions.AlreadyExists:
+                logger.info(
+                    "Skipping already submitted tasks, probably because of a timeout error. "
+                    "Check that the compute plan has the right number of tasks once the submission is complete."
+                )
+                continue
 
     def _add_tuples(self, batch, spec_options):
         batch_data = []


### PR DESCRIPTION
## Bug

Submitting a CP with a large number of tasks

The CP that generates this error did start and run, but not all the tuples were submitted. However, in the front, you could miss that info if you don’t look carefully at the number of tasks in the CP

```python
Requests error status 504: <html>
<head><title>504 Gateway Time-out</title></head>
<body>
<center><h1>504 Gateway Time-out</h1></center>
<hr><center>nginx</center>
</body>
</html>

WARNING:root:Function _request failed: retrying in 1s
ERROR:substra.sdk.backends.remote.rest_client:Requests error status 409: {"message":"OE0006: computetask with key \"fc31fba9-87e6-457c-8632-f28e87998830\" already exists"}
Traceback (most recent call last):
  File "MASKED/python3.7/site-packages/substra/sdk/backends/remote/rest_client.py", line 114, in __request
    r.raise_for_status()
  File "MASKED/python3.7/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://MASKED/task/bulk_create/

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "fl_train.py", line 181, in <module>
    run_fl_exp(config)
  File "fl_train.py", line 157, in run_fl_exp
    task_submission_batch_size=20,
  File "MASKED/python3.7/site-packages/connectlib/experiment.py", line 372, in execute_experiment
    batch_size=task_submission_batch_size,
  File "MASKED/python3.7/site-packages/substra/sdk/client.py", line 48, in wrapper
    return f(*args, **kwargs)
  File "MASKED/python3.7/site-packages/substra/sdk/client.py", line 435, in add_compute_plan
    return self._backend.add(spec, spec_options=spec_options)
  File "MASKED/python3.7/site-packages/substra/sdk/backends/remote/backend.py", line 172, in add
    self._add_tuples_from_computeplan(spec, spec_options, auto_batching, batch_size)
  File "MASKED/python3.7/site-packages/substra/sdk/backends/remote/backend.py", line 223, in _add_tuples_from_computeplan
    self._add_tuples(batch, spec_options)
  File "MASKED/python3.7/site-packages/substra/sdk/backends/remote/backend.py", line 234, in _add_tuples
    json={"tasks": batch_data},
  File "MASKED/python3.7/site-packages/substra/sdk/backends/remote/rest_client.py", line 206, in request
    **request_kwargs,
  File "MASKED/python3.7/site-packages/substra/sdk/utils.py", line 228, in wrapper
    return f(*args, **kwargs)
  File "MASKED/python3.7/site-packages/substra/sdk/backends/remote/rest_client.py", line 159, in _request
    return self.__request(request_name, url, **request_kwargs)
  File "MASKED/python3.7/site-packages/substra/sdk/backends/remote/rest_client.py", line 141, in __request
    raise exceptions.AlreadyExists.from_request_exception(e)
substra.sdk.exceptions.AlreadyExists: Object with key(s) 'None' already exists.
```

## Summary

What happened is that:
 the SDK registers n tasks
The backend receive the request and start processing it
The server is too slow to respond so the proxy cuts the network
The backend correctly create the tuples but do not send a response because the client is disconnected
The SDK retries creating the same batch because of the network error
The backend respond with an error saying that these tuples are already present.

Solution here: when submitting by batches, the SDK catches this error and continues the submission

## Notes

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
