### PR TITLE
Retry timeout cp submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prevent use of `__` in asset metadata keys in local mode
 - docker: add build logs to container image build exception messages
+- At compute plan submission by batch, continue the submission after a timeout error
 
 ## [0.38.0](https://github.com/Substra/substra/releases/tag/0.38.0) - 2022-09-26
 

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -206,7 +206,14 @@ class Remote(base.BaseBackend):
             batches = [tuples]
 
         for batch in batches:
-            self._add_tuples(batch, spec_options)
+            try:
+                self._add_tuples(batch, spec_options)
+            except exceptions.AlreadyExists:
+                logger.warning(
+                    "Skipping already submitted tasks, probably because of a timeout error. "
+                    "Check that the compute plan has the right number of tasks once the submission is complete."
+                )
+                continue
 
     def _add_tuples(self, batch, spec_options):
         batch_data = []


### PR DESCRIPTION
## Related issue

Including the patch in main:
https://github.com/Substra/substra/pull/296

What happened is that:

-  the SDK registers n tasks
- The backend receive the request and start processing it
- The server is too slow to respond so the proxy cuts the network
- The backend correctly create the tuples but do not send a response because the client is disconnected
- The SDK retries creating the same batch because of the network error
- The backend respond with an error saying that these tuples are already present.

The SDK should probably react on this error and check the tuples that are already submitted or not and submit only the missing ones

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
