### PR TITLE
docs: Add new documentation URL and new Slack URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<div align="left">
+<a href="https://join.slack.com/t/substra-workspace/shared_invite/zt-1fqnk0nw6-xoPwuLJ8dAPXThfyldX8yA"><img src="https://img.shields.io/badge/chat-on%20slack-blue?logo=slack" /></a> <a href="https://docs.substra.org/"><img src="https://img.shields.io/badge/read-docs-purple?logo=mdbook" /></a>
+<br /><br /></div>
+
 <div align="center">
   <img src="substra_horizontal-color.svg" width="600"/>
 </div>
@@ -5,7 +9,7 @@
 Substra is a python library and a command line interface to interact with the Substra platform.
 For more information on what is substra and how to use it, please refer to the [user documentation](https://docs.substra.org/).
 
-Join the discussion on [Slack](https://substra-workspace.slack.com/)!
+Join the discussion on [Slack](https://join.slack.com/t/substra-workspace/shared_invite/zt-1fqnk0nw6-xoPwuLJ8dAPXThfyldX8yA)!
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </div>
 
 Substra is a python library and a command line interface to interact with the Substra platform.
-For more information on what is substra and how to use is, please refer to the [user documentation](https://connect-docs.owkin.com/en/stable/).
+For more information on what is substra and how to use it, please refer to the [user documentation](https://docs.substra.org/).
 
-To discuss on Slack, please join the [substra-general](https://lfaifoundation.slack.com/#substra-general) channel and the [substra-help](https://lfaifoundation.slack.com/#substra-help) channel.
+Join the discussion on [Slack](https://substra-workspace.slack.com/)!
 
 ## Contributing
 


### PR DESCRIPTION
 Add new documentation URL and new Slack URL

Signed-off-by: Romain Goussault <romain.goussault@owkin.com>


## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
