### PR TITLE
fix: return value of link_dataset_with_data_samples in remote mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- link_dataset_with_data_samples return value in remote mode
+
 ## [0.39.0](https://github.com/Substra/substra/releases/tag/0.39.0) - 2022-10-03
 
 ### Removed

--- a/references/cli.md
+++ b/references/cli.md
@@ -71,8 +71,7 @@ Options:
 ```text
 Usage: substra cancel compute_plan [OPTIONS] COMPUTE_PLAN_KEY
 
-  Cancel execution of a compute plan. Nothing is printed, you can check again
-  the compute plan status with `substra get compute_plan`.
+  Cancel execution of a compute plan.
 
 Options:
   --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]

--- a/substra/sdk/backends/base.py
+++ b/substra/sdk/backends/base.py
@@ -1,4 +1,5 @@
 import abc
+from typing import List
 
 from substra.sdk.schemas import BackendType
 
@@ -34,7 +35,7 @@ class BaseBackend(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def link_dataset_with_data_samples(self, dataset_key, data_sample_keys):
+    def link_dataset_with_data_samples(self, dataset_key, data_sample_keys) -> List[str]:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -753,7 +753,7 @@ class Local(base.BaseBackend):
                 add_asset(key, spec, spec_options)
                 return key
 
-    def link_dataset_with_data_samples(self, dataset_key, data_sample_keys):
+    def link_dataset_with_data_samples(self, dataset_key, data_sample_keys) -> List[str]:
         dataset = self._db.get(schemas.Type.Dataset, dataset_key)
         data_samples = list()
         for key in data_sample_keys:

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -266,7 +266,7 @@ class Remote(base.BaseBackend):
             key=spec.key,
         )
 
-    def link_dataset_with_data_samples(self, dataset_key, data_sample_keys):
+    def link_dataset_with_data_samples(self, dataset_key, data_sample_keys) -> List[str]:
         """Returns the list of the data sample keys"""
         data = {
             "data_manager_keys": [dataset_key],

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -278,6 +278,7 @@ class Remote(base.BaseBackend):
             path="bulk_update/",
             data=data,
         )
+        return data_sample_keys
 
     def _download(self, url: str, destination_file: str) -> str:
         response = self._client.get_data(url, stream=True)


### PR DESCRIPTION
There was a return statement missing. While I was there, I added type hints.

If accepted, this fix should be backported to the 0.38.x release.
