### PR TITLE
feat: archive dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - link_dataset_with_data_samples return value in remote mode
 
+
+### Added
+
+- dataset method to archive the asset
+
 ## [0.39.0](https://github.com/Substra/substra/releases/tag/0.39.0) - 2022-10-03
 
 ### Removed

--- a/substra/sdk/backends/base.py
+++ b/substra/sdk/backends/base.py
@@ -29,7 +29,7 @@ class BaseBackend(abc.ABC):
     @abc.abstractmethod
     def update(self, key, spec, spec_options=None):
         raise NotImplementedError
-    
+
     @abc.abstractmethod
     def archive(self, key, spec, spec_options=None):
         raise NotImplementedError

--- a/substra/sdk/backends/base.py
+++ b/substra/sdk/backends/base.py
@@ -29,6 +29,10 @@ class BaseBackend(abc.ABC):
     @abc.abstractmethod
     def update(self, key, spec, spec_options=None):
         raise NotImplementedError
+    
+    @abc.abstractmethod
+    def archive(self, key, spec, spec_options=None):
+        raise NotImplementedError
 
     @abc.abstractmethod
     def add_compute_plan_tuples(self, spec, spec_options):

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -832,6 +832,15 @@ class Local(base.BaseBackend):
         self._db.update(updated_asset)
         return
 
+    def archive(self, key, spec, spec_options=None):
+        asset_type = spec.__class__.type_
+        asset = self.get(asset_type, key)
+        data = asset.dict()
+        data.update(spec.dict())
+        archived_asset = models.SCHEMA_TO_MODEL[asset_type](**data)
+        self._db.update(archived_asset)
+        return
+
     def add_compute_plan_tuples(self, spec: schemas.UpdateComputePlanTuplesSpec, spec_options: dict = None):
         key = spec.key
         compute_plan = self._db.get(schemas.Type.ComputePlan, key)

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -255,6 +255,16 @@ class Remote(base.BaseBackend):
         with spec.build_request_kwargs(**spec_options) as (data, files):
             return self._update(asset_type, key, data, files=files)
 
+    def archive(self, key, spec, spec_options=None):
+        spec_options = spec_options or {}
+        asset_type = spec.__class__.type_
+        with spec.build_request_kwargs(**spec_options) as (data, files):
+            kwargs = {
+                "json": data,
+            }
+            data = deepcopy(data) 
+            return self._client.request("put", asset_type, key, **kwargs)
+
     def add_compute_plan_tuples(self, spec, spec_options):
         # Remove auto_batching and batch_size from spec_options
         auto_batching = spec_options.pop(AUTO_BATCHING, False)

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -262,7 +262,7 @@ class Remote(base.BaseBackend):
             kwargs = {
                 "json": data,
             }
-            data = deepcopy(data) 
+            data = deepcopy(data)
             return self._client.request("put", asset_type, key, **kwargs)
 
     def add_compute_plan_tuples(self, spec, spec_options):

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -907,6 +907,12 @@ class Client:
         return
 
     @logit
+    def archive_dataset(self, key: str, archived: bool):
+        spec = self._get_spec(schemas.ArchiveDatasetSpec, {"archived": archived})
+        self._backend.archive(key, spec)
+        return
+
+    @logit
     def link_dataset_with_data_samples(
         self,
         dataset_key: str,

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -344,6 +344,14 @@ class UpdateDatasetSpec(_Spec):
     type_: typing.ClassVar[Type] = Type.Dataset
 
 
+class ArchiveDatasetSpec(_Spec):
+    """Specification for archiving a dataset"""
+
+    archived: bool
+
+    type_: typing.ClassVar[Type] = Type.Dataset
+
+
 class AlgoInputSpec(_Spec):
     identifier: str
     multiple: bool

--- a/tests/sdk/test_archive.py
+++ b/tests/sdk/test_archive.py
@@ -1,97 +1,27 @@
-import os
-import shutil
-import tarfile
-import tempfile
-
 import pytest
 
-from substra.sdk.archive import _untar
-from substra.sdk.archive import _unzip
-from substra.sdk.archive import tarsafe
-from substra.sdk.archive.safezip import ZipFile
+from substra.sdk import models
+from substra.sdk import schemas
+
+from .. import datastore
+from ..utils import mock_requests
 
 
-class TestsZipFile:
 
-    # This zip file was specifically crafted and contains empty files named:
-    # foo/bar
-    # ../foo/bar
-    # ../../foo/bar
-    # ../../../foo/bar
-    TRAVERSAL_ZIP = os.path.join(os.path.dirname(__file__), "data", "traversal.zip")
+def test_archive_dataset(client, mocker):
+    archive_method = getattr(client, f"archive_dataset")
+    get_method = getattr(client, f"get_dataset")
 
-    # This zip file was specifically crafted and contains:
-    # bar
-    # foo -> bar (symlink)
-    SYMLINK_ZIP = os.path.join(os.path.dirname(__file__), "data", "symlink.zip")
+    item = getattr(datastore, "DATASET")
+    archived_field = {"archived": True}
+    archived_dataset = {**item, **archived_field}
 
-    def test_raise_on_path_traversal(self):
-        zf = ZipFile(self.TRAVERSAL_ZIP, "r")
-        with pytest.raises(Exception) as exc:
-            zf.extractall(tempfile.gettempdir())
+    m_put = mock_requests(mocker, "put")
+    m_get = mock_requests(mocker, "get", response=item)
 
-        assert "Attempted directory traversal" in str(exc.value)
+    archive_method("magic-key", archived_field["archived"])
+    response = get_method("magic-key")
 
-    def test_raise_on_symlink(self):
-        zf = ZipFile(self.SYMLINK_ZIP, "r")
-        with pytest.raises(Exception) as exc:
-            zf.extractall(tempfile.gettempdir())
-
-        assert "Unsupported symlink" in str(exc.value)
-
-    def test_compress_uncompress_zip(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            path_testdir = os.path.join(tmpdirname, "testdir")
-            os.makedirs(path_testdir)
-            with open(os.path.join(path_testdir, "testfile.txt"), "w") as f:
-                f.write("testtext")
-            shutil.make_archive(os.path.join(tmpdirname, "test_archive"), "zip", root_dir=os.path.dirname(path_testdir))
-            _unzip(os.path.join(tmpdirname, "test_archive.zip"), os.path.join(tmpdirname, "test_archive"))
-
-            assert os.listdir(tmpdirname + "/test_archive/testdir") == ["testfile.txt"]
-
-
-class TestsTarSafe:
-    def test_compress_uncompress_tar(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            path_testdir = os.path.join(tmpdirname, "testdir")
-            os.makedirs(path_testdir)
-            with open(os.path.join(path_testdir, "testfile.txt"), "w") as f:
-                f.write("testtext")
-            path_tarfile = os.path.join(tmpdirname, "test_archive.tar")
-            with tarsafe.open(path_tarfile, "w:gz") as tar:
-                tar.add(path_testdir, arcname=os.path.basename(path_testdir))
-
-            _untar(path_tarfile, os.path.join(tmpdirname, "test_archive"))
-
-            assert os.listdir(tmpdirname + "/test_archive/testdir") == ["testfile.txt"]
-
-    def test_raise_on_symlink(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-
-            # create the following tree structure:
-            # ./Dockerfile
-            # ./foo
-            #    ./Dockerfile -> ../Dockerfile
-
-            filename = "Dockerfile"
-            symlink_source = os.path.join(tmpdir, filename)
-            with open(symlink_source, "w") as fp:
-                fp.write("FROM bar")
-
-            archive_root = os.path.join(tmpdir, "foo")
-            os.mkdir(archive_root)
-            os.symlink(symlink_source, os.path.join(archive_root, filename))
-
-            # create a tar archive of the foo folder
-            tarpath = os.path.join(tmpdir, "foo.tgz")
-            with tarfile.open(tarpath, "w:gz") as tar:
-                for root, _, files in os.walk(archive_root):
-                    for file in files:
-                        tar.add(os.path.join(root, file))
-
-            with pytest.raises(tarsafe.TarSafeError) as error:
-                with tarsafe.open(tarpath, "r") as tar:
-                    tar.extractall()
-
-                assert "Unsupported symlink" in str(error.exception)
+    assert response == models.SCHEMA_TO_MODEL[schemas.Type("dataset")](**archived_dataset)
+    m_put.assert_called()
+    m_get.assert_called()

--- a/tests/sdk/test_archive_file.py
+++ b/tests/sdk/test_archive_file.py
@@ -1,0 +1,97 @@
+import os
+import shutil
+import tarfile
+import tempfile
+
+import pytest
+
+from substra.sdk.archive import _untar
+from substra.sdk.archive import _unzip
+from substra.sdk.archive import tarsafe
+from substra.sdk.archive.safezip import ZipFile
+
+
+class TestsZipFile:
+
+    # This zip file was specifically crafted and contains empty files named:
+    # foo/bar
+    # ../foo/bar
+    # ../../foo/bar
+    # ../../../foo/bar
+    TRAVERSAL_ZIP = os.path.join(os.path.dirname(__file__), "data", "traversal.zip")
+
+    # This zip file was specifically crafted and contains:
+    # bar
+    # foo -> bar (symlink)
+    SYMLINK_ZIP = os.path.join(os.path.dirname(__file__), "data", "symlink.zip")
+
+    def test_raise_on_path_traversal(self):
+        zf = ZipFile(self.TRAVERSAL_ZIP, "r")
+        with pytest.raises(Exception) as exc:
+            zf.extractall(tempfile.gettempdir())
+
+        assert "Attempted directory traversal" in str(exc.value)
+
+    def test_raise_on_symlink(self):
+        zf = ZipFile(self.SYMLINK_ZIP, "r")
+        with pytest.raises(Exception) as exc:
+            zf.extractall(tempfile.gettempdir())
+
+        assert "Unsupported symlink" in str(exc.value)
+
+    def test_compress_uncompress_zip(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path_testdir = os.path.join(tmpdirname, "testdir")
+            os.makedirs(path_testdir)
+            with open(os.path.join(path_testdir, "testfile.txt"), "w") as f:
+                f.write("testtext")
+            shutil.make_archive(os.path.join(tmpdirname, "test_archive"), "zip", root_dir=os.path.dirname(path_testdir))
+            _unzip(os.path.join(tmpdirname, "test_archive.zip"), os.path.join(tmpdirname, "test_archive"))
+
+            assert os.listdir(tmpdirname + "/test_archive/testdir") == ["testfile.txt"]
+
+
+class TestsTarSafe:
+    def test_compress_uncompress_tar(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path_testdir = os.path.join(tmpdirname, "testdir")
+            os.makedirs(path_testdir)
+            with open(os.path.join(path_testdir, "testfile.txt"), "w") as f:
+                f.write("testtext")
+            path_tarfile = os.path.join(tmpdirname, "test_archive.tar")
+            with tarsafe.open(path_tarfile, "w:gz") as tar:
+                tar.add(path_testdir, arcname=os.path.basename(path_testdir))
+
+            _untar(path_tarfile, os.path.join(tmpdirname, "test_archive"))
+
+            assert os.listdir(tmpdirname + "/test_archive/testdir") == ["testfile.txt"]
+
+    def test_raise_on_symlink(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+
+            # create the following tree structure:
+            # ./Dockerfile
+            # ./foo
+            #    ./Dockerfile -> ../Dockerfile
+
+            filename = "Dockerfile"
+            symlink_source = os.path.join(tmpdir, filename)
+            with open(symlink_source, "w") as fp:
+                fp.write("FROM bar")
+
+            archive_root = os.path.join(tmpdir, "foo")
+            os.mkdir(archive_root)
+            os.symlink(symlink_source, os.path.join(archive_root, filename))
+
+            # create a tar archive of the foo folder
+            tarpath = os.path.join(tmpdir, "foo.tgz")
+            with tarfile.open(tarpath, "w:gz") as tar:
+                for root, _, files in os.walk(archive_root):
+                    for file in files:
+                        tar.add(os.path.join(root, file))
+
+            with pytest.raises(tarsafe.TarSafeError) as error:
+                with tarsafe.open(tarpath, "r") as tar:
+                    tar.extractall()
+
+                assert "Unsupported symlink" in str(error.exception)


### PR DESCRIPTION
## Summary

New endpoint to archive and dearchive a dataset see [asana card](https://app.asana.com/0/1201599852028640/1202944294601335/f)

## Connected-PR

- substra-backend [#521](https://github.com/Substra/substra-backend/pull/521)
- orchestrator [#54](https://github.com/Substra/orchestrator/pull/54)
- substra sdk [#35](https://github.com/Substra/substra/pull/305) -> this PR

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)