### PR TITLE
feat: remove failed task category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,10 @@ compute_plan = client.add_compute_plan(
 - Register functions in substratools using decorator `@tools.register` (#310)
 - Update README image (#318)
 
+### Removed
+
+- BREAKING CHANGE: failed task category
+
 ## [0.39.0](https://github.com/Substra/substra/releases/tag/0.39.0) - 2022-10-03
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- BREAKING CHANGE: failed task category (#309)
 - BREAKING: DataSampleSpec don't have a `test_only` field anymore (#332)
 
 ### Changed
@@ -125,10 +126,6 @@ compute_plan = client.add_compute_plan(
 - Apply changes from algo to function in substratools (#303)
 - Register functions in substratools using decorator `@tools.register` (#310)
 - Update README image (#318)
-
-### Removed
-
-- BREAKING CHANGE: failed task category
 
 ## [0.39.0](https://github.com/Substra/substra/releases/tag/0.39.0) - 2022-10-03
 

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -1,23 +1,22 @@
 # Summary
 
-- [DataSample](#datasample)
-- [Dataset](#dataset)
-- [Task](#task)
-- [Function](#function)
-- [ComputePlan](#computeplan)
-- [Performances](#performances)
-- [Organization](#organization)
-- [Permissions](#permissions)
-- [InModel](#inmodel)
-- [OutModel](#outmodel)
-- [_File](#_file)
+- [DataSample](#DataSample)
+- [Dataset](#Dataset)
+- [Task](#Task)
+- [Function](#Function)
+- [ComputePlan](#ComputePlan)
+- [Performances](#Performances)
+- [Organization](#Organization)
+- [Permissions](#Permissions)
+- [InModel](#InModel)
+- [OutModel](#OutModel)
+- [_File](#_File)
+
 
 # Models
 
 ## DataSample
-
 Data sample
-
 ```text
 - key: str
 - owner: str
@@ -27,9 +26,7 @@ Data sample
 ```
 
 ## Dataset
-
 Dataset asset
-
 ```text
 - key: str
 - name: str
@@ -45,9 +42,7 @@ Dataset asset
 ```
 
 ## Task
-
 Asset creation specification base class.
-
 ```text
 - key: str
 - function: Function
@@ -67,9 +62,7 @@ Asset creation specification base class.
 ```
 
 ## Function
-
 Asset creation specification base class.
-
 ```text
 - key: str
 - name: str
@@ -84,9 +77,7 @@ Asset creation specification base class.
 ```
 
 ## ComputePlan
-
 ComputePlan
-
 ```text
 - key: str
 - tag: str
@@ -111,9 +102,7 @@ ComputePlan
 ```
 
 ## Performances
-
 Performances of the different compute tasks of a compute plan
-
 ```text
 - compute_plan_key: List[str]
 - compute_plan_tag: List[str]
@@ -122,17 +111,15 @@ Performances of the different compute tasks of a compute plan
 - compute_plan_end_date: List[datetime]
 - compute_plan_metadata: List[dict]
 - worker: List[str]
-- testtask_key: List[str]
-- metric_name: List[str]
-- testtask_rank: List[int]
+- task_key: List[str]
+- function_name: List[str]
+- task_rank: List[int]
 - round_idx: List[int]
 - performance: List[float]
 ```
 
 ## Organization
-
 Organization
-
 ```text
 - id: str
 - is_current: bool
@@ -140,26 +127,20 @@ Organization
 ```
 
 ## Permissions
-
 Permissions structure stored in various asset types.
-
 ```text
 - process: Permission
 ```
 
 ## InModel
-
 In model of a task
-
 ```text
 - checksum: str
 - storage_address: Union[FilePath, AnyUrl, str]
 ```
 
 ## OutModel
-
 Out model of a task
-
 ```text
 - key: str
 - compute_task_key: str
@@ -170,10 +151,9 @@ Out model of a task
 ```
 
 ## _File
-
 File as stored in the models
-
 ```text
 - checksum: str
 - storage_address: Union[FilePath, AnyUrl, str]
 ```
+

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -1,22 +1,23 @@
 # Summary
 
-- [DataSample](#DataSample)
-- [Dataset](#Dataset)
-- [Task](#Task)
-- [Function](#Function)
-- [ComputePlan](#ComputePlan)
-- [Performances](#Performances)
-- [Organization](#Organization)
-- [Permissions](#Permissions)
-- [InModel](#InModel)
-- [OutModel](#OutModel)
-- [_File](#_File)
-
+- [DataSample](#datasample)
+- [Dataset](#dataset)
+- [Task](#task)
+- [Function](#function)
+- [ComputePlan](#computeplan)
+- [Performances](#performances)
+- [Organization](#organization)
+- [Permissions](#permissions)
+- [InModel](#inmodel)
+- [OutModel](#outmodel)
+- [_File](#_file)
 
 # Models
 
 ## DataSample
+
 Data sample
+
 ```text
 - key: str
 - owner: str
@@ -26,7 +27,9 @@ Data sample
 ```
 
 ## Dataset
+
 Dataset asset
+
 ```text
 - key: str
 - name: str
@@ -42,7 +45,9 @@ Dataset asset
 ```
 
 ## Task
+
 Asset creation specification base class.
+
 ```text
 - key: str
 - function: Function
@@ -62,7 +67,9 @@ Asset creation specification base class.
 ```
 
 ## Function
+
 Asset creation specification base class.
+
 ```text
 - key: str
 - name: str
@@ -77,7 +84,9 @@ Asset creation specification base class.
 ```
 
 ## ComputePlan
+
 ComputePlan
+
 ```text
 - key: str
 - tag: str
@@ -91,7 +100,7 @@ ComputePlan
 - canceled_count: int
 - failed_count: int
 - done_count: int
-- failed_task: Optional[FailedTask]
+- failed_task_key: Optional[str]
 - status: ComputePlanStatus
 - creation_date: datetime
 - start_date: Optional[datetime]
@@ -102,7 +111,9 @@ ComputePlan
 ```
 
 ## Performances
+
 Performances of the different compute tasks of a compute plan
+
 ```text
 - compute_plan_key: List[str]
 - compute_plan_tag: List[str]
@@ -119,7 +130,9 @@ Performances of the different compute tasks of a compute plan
 ```
 
 ## Organization
+
 Organization
+
 ```text
 - id: str
 - is_current: bool
@@ -127,20 +140,26 @@ Organization
 ```
 
 ## Permissions
+
 Permissions structure stored in various asset types.
+
 ```text
 - process: Permission
 ```
 
 ## InModel
+
 In model of a task
+
 ```text
 - checksum: str
 - storage_address: Union[FilePath, AnyUrl, str]
 ```
 
 ## OutModel
+
 Out model of a task
+
 ```text
 - key: str
 - compute_task_key: str
@@ -151,9 +170,10 @@ Out model of a task
 ```
 
 ## _File
+
 File as stored in the models
+
 ```text
 - checksum: str
 - storage_address: Union[FilePath, AnyUrl, str]
 ```
-

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -296,13 +296,6 @@ class Task(_Model):
 Task.update_forward_refs()
 
 
-class FailedTask(_Model):
-    """Info on failed task."""
-
-    key: str
-    category: str
-
-
 class ComputePlan(_Model):
     """ComputePlan"""
 
@@ -318,7 +311,7 @@ class ComputePlan(_Model):
     canceled_count: int = 0
     failed_count: int = 0
     done_count: int = 0
-    failed_task: Optional[FailedTask]
+    failed_task_key: Optional[str]
     status: ComputePlanStatus
     creation_date: datetime
     start_date: Optional[datetime]


### PR DESCRIPTION
Signed-off-by: Serge Bouchut <serge.bouchut@owkin.com>

## Related issue

`#` followed by the number of the issue

## Summary

Remove failed task category deprecated field.
See: https://github.com/Substra/substra-backend/pull/525

## Notes

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
