### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: Report bug or performance issue
+title: "BUG: "
+labels: [Bug]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: context
+    attributes:
+      label: What are you trying to do?
+      description: >
+        Please provide some context on what you are trying to achieve.
+      placeholder:
+    validations:
+      required: true
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue Description (what is happening?)
+      description: >
+        Please provide a description of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior (what should happen?)
+      description: >
+        Please describe or show a code example of the expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: example
+    attributes:
+      label: Reproducible Example
+      description: >
+        If possible, provide a reproducible example.
+      render: python
+
+  - type: textarea
+    id: os-version
+    attributes:
+      label: Operating system
+      description: >
+        Which operating system are you using? (Provide the version number)
+    validations:
+      required: true
+  - type: textarea
+    id: substra-version
+    attributes:
+      label: Installed Substra versions
+      description: >
+        Which version of `substrafl`/ `substra` / `substra-tools` are you using?
+        You can check if there are compatible in the [compatibility table](https://docs.substra.org/en/stable/additional/release.html#compatibility-table).
+      placeholder: >
+              pip freeze | grep substra
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies-version
+    attributes:
+      label: Installed versions of dependencies
+      description: >
+        Please provide versions of dependencies which might be relevant to your issue (eg. `helm` and `skaffold` version for a deployment issue, `numpy` and `pytorch` for an algorithmic issue).
+
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Stacktrace
+      description: >
+        Please copy-paste here any log and/or stacktrace that might be relevant. Remove confidential and personal information if necessary.

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -50,14 +50,24 @@ body:
     validations:
       required: true
   - type: textarea
+    id: os-version
+    attributes:
+      label: Python version
+      description: >
+        Which Python version are you using?
+      placeholder: >
+        python --version
+    validations:
+      required: true
+  - type: textarea
     id: substra-version
     attributes:
       label: Installed Substra versions
       description: >
         Which version of `substrafl`/ `substra` / `substra-tools` are you using?
-        You can check if there are compatible in the [compatibility table](https://docs.substra.org/en/stable/additional/release.html#compatibility-table).
+        You can check if they are compatible in the [compatibility table](https://docs.substra.org/en/stable/additional/release.html#compatibility-table).
       placeholder: >
-              pip freeze | grep substra
+        pip freeze | grep substra
       render: python
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question
+    url: https://join.slack.com/t/substra-workspace/shared_invite/zt-1fqnk0nw6-xoPwuLJ8dAPXThfyldX8yA
+    about: Don't hesitate to join the Substra community on Slack to ask all your questions!
+  - name: User Documentation Improvements
+    url: https://github.com/Substra/substra-documentation/issues
+    about: For issues related to the User Documentation, please open an issue on the substra-documentation repository

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest an idea for substra
+description: Suggest an idea for Substra
 title: "ENH: "
 labels: [Enhancement]
 
@@ -11,19 +11,17 @@ body:
       description: Please check what type of feature request you would like to propose.
       options:
         - label: >
-            Adding new functionality to substra
+            Adding new functionality to Substra
         - label: >
-            Changing existing functionality in substra
+            Changing existing functionality in Substra
         - label: >
-            Removing existing functionality in substra
+            Removing existing functionality in Substra
   - type: textarea
     id: description
     attributes:
       label: Problem Description
       description: >
-        Please describe what problem the feature would solve, e.g. "I wish I could use substra to ..."
-      placeholder: >
-        A clear and concise description of what the problem is.
+        Please describe what problem the feature would solve, e.g. "I wish I could use Substra to ..."
     validations:
       required: true
   - type: textarea
@@ -31,9 +29,7 @@ body:
     attributes:
       label: Feature Description
       description: >
-        Please describe how the new feature would be implemented, using pseudocode if relevant.
-      placeholder: >
-        A clear and concise description of what you want to happen.
+        Please describe what will be this new feature.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,52 @@
+name: Feature Request
+description: Suggest an idea for substra
+title: "ENH: "
+labels: [Enhancement]
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Feature Type
+      description: Please check what type of feature request you would like to propose.
+      options:
+        - label: >
+            Adding new functionality to substra
+        - label: >
+            Changing existing functionality in substra
+        - label: >
+            Removing existing functionality in substra
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem Description
+      description: >
+        Please describe what problem the feature would solve, e.g. "I wish I could use substra to ..."
+      placeholder: >
+        A clear and concise description of what the problem is.
+    validations:
+      required: true
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature Description
+      description: >
+        Please describe how the new feature would be implemented, using pseudocode if relevant.
+      placeholder: >
+        A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Alternative Solutions
+      description: >
+        Please describe any alternative solution (existing functionality, 3rd party package, etc.)
+        that would satisfy the feature request.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: >
+        Please provide any relevant GitHub issues, code examples or references that help describe and support
+        the feature request.


### PR DESCRIPTION
Signed-off-by: SdgJlbl <sarah.diot-girard@owkin.com>

## Related issue

https://app.asana.com/0/1203124674173179/1203854905218734/f

## Summary

Add templates for Github issues

## Notes

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [X] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification

