### PR TITLE
docs: update readme image URL for Pypi readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 <div align="center">
 <picture>
   <object-position: center>
-  <source media="(prefers-color-scheme: dark)" srcset="Substra-logo-white.svg">
-  <source media="(prefers-color-scheme: light)" srcset="Substra-logo-colour.svg">
-  <img alt="Substra" src="Substra-logo-colour.svg" width="500">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/substra/substra/main/Substra-logo-white.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/substra/substra/main/Substra-logo-colour.svg">
+  <img alt="Substra" src="https://raw.githubusercontent.com/substra/substra/main/Substra-logo-colour.svg" width="500">
 </picture>
 </div>
 <br>


### PR DESCRIPTION
## Related issue

[Pypi README](https://pypi.org/project/substra/) did not have the Substra logo image.

This PR should solve this.
This is based on this [stackoverflow thread](https://stackoverflow.com/questions/41983209/how-do-i-add-images-to-a-pypi-readme-that-works-on-github).

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
