### PR TITLE
feat: add client.login_with_token

### DIFF
--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -150,6 +150,14 @@ class Client:
         self._token = self._backend.login(username, password)
         return self._token
 
+    @logit
+    def login_with_token(self, token) -> None:
+        """Login to a remote server using a bearer token."""
+        # TODO: maybe it should call a /check-token endpoint or something
+        if not self._backend:
+            raise exceptions.SDKException("No backend found")
+        self._token = token
+
     @staticmethod
     def _get_spec(asset_type, data):
         if isinstance(data, asset_type):


### PR DESCRIPTION
## Summary

This PR adds `Client.login_with_token` method, which is an alternative to `Client.login`. Instead of calling a backend endpoint to get a token, just directly use a token.

This is intended for use as part of the single-sign on scheme: SSO users have no password, so they cannot use the current `login` method. Instead, they will manually retrieve a bearer token and use it with `Client.login_with_token`.

Open questions:
 - maybe it should be `use_token` (or `log_in_with_token`)
 - maybe we should try contacting the API to make sure the token works

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
