### PR TITLE
feat!: client configuration with environment variables or configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Client can now be configured using environment variables or a configuration Yaml file ([#353](https://github.com/Substra/substra/pull/353))
+
+### Changed
+
+- BREAKING: default backend type for Client is now "subprocess" ([#353](https://github.com/Substra/substra/pull/353))
+
 ## [0.43.0](https://github.com/Substra/substra/releases/tag/0.43.0) - 2023-03-31
 
 ### Added

--- a/bin/generate_cli_documentation.py
+++ b/bin/generate_cli_documentation.py
@@ -23,7 +23,6 @@ def _click_parse_node(name, command, parent, callback):
 
 
 def click_get_commands(name, command):
-
     commands = []
 
     def cb(command_path):

--- a/bin/generate_sdk_schemas_documentation.py
+++ b/bin/generate_sdk_schemas_documentation.py
@@ -49,7 +49,6 @@ def _get_field_description(fields):
 
 
 def generate_help(fh, models: bool):
-
     if models:
         asset_list = models_list
         title = "Models"
@@ -89,7 +88,6 @@ def write_help(path, models: bool):
 
 
 if __name__ == "__main__":
-
     expected_pydantic_version = "1.9.0"
     if pydantic.VERSION != expected_pydantic_version:
         warnings.warn(

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -1,27 +1,48 @@
 # Client
 ```text
-Client(url: Optional[str] = None, token: Optional[str] = None, retry_timeout: int = 300, insecure: bool = False, backend_type: substra.sdk.schemas.BackendType = <BackendType.REMOTE: 'remote'>)
+Client(*, configuration_name: Optional[str] = None, configuration_file: Optional[pathlib.Path] = None, url: Optional[str] = None, token: Optional[str] = None, username: Optional[str] = None, password: Optional[str] = None, retry_timeout: Optional[int] = None, insecure: Optional[bool] = None, backend_type: Optional[substra.sdk.schemas.BackendType] = None)
 ```
 
-Create a client
+Create a client.
+Defaults to a subprocess client, suitable for development purpose.
+Configuration can be passed in the code, through environment variables or through a configuration file.
+The order of precedence is: values defined by the user in the code, environment variables, values read from the
+configuration file. If the attribute is not set, the value returned is None (and the origin is set to "default").
+In order to use configuration values not explicitly defined in the code, the parameter `configuration_name` must
+not be None.
 
 **Arguments:**
- - `url (str, optional)`: URL of the Substra platform. Mandatory
-to connect to a Substra platform. If no URL is given debug must be True and all
-assets must be created locally.
+ - `configuration_name (str, optional)`: Name of the configuration.
+Used to load relevant environment variables and select the right dictionary in the configuration file.
+Defaults to None.
+ - `configuration_file (path, optional)`: Path to te configuration file.
+`configuration_name` must be defined too.
+Defaults to None.
+ - `url (str, optional)`: URL of the Substra platform.
+Mandatory to connect to a Substra platform. If no URL is given, all assets are created locally.
+Can be set to "" to remove any previously defined URL (in a configuration file or environment variable).
 Defaults to None.
  - `token (str, optional)`: Token to authenticate to the Substra platform.
-If no token is given, use the 'login' function to authenticate.
+If no token is given, and a `username`/ `password` pair is provided,  the Client will try to authenticate
+using 'login' function. It's always possible to generate a new token later by making another call to the
+`login` function.
 Defaults to None.
- - `retry_timeout (int, optional)`: Number of seconds before attempting a retry call in case
-of timeout.
+ - `username (str, optional)`: Username to authenticate to the Substra platform.
+Used in conjunction with a password to generate a token if not given, using the `login` function.
+Not stored.
+Defaults to None.
+ - `password (str, optional)`: Password to authenticate to the Substra platform.
+Used in conjunction with a username to generate a token if not given, using the `login` function.
+Not stored.
+Defaults to None.
+ - `retry_timeout (int, optional)`: Number of seconds before attempting a retry call in case of timeout.
 Defaults to 5 minutes.
- - `insecure (bool, optional)`: If True, the client can call a not-certified backend. This is
-for development purposes.
+ - `insecure (bool, optional)`: If True, the client can call a not-certified backend.
+This is for development purposes.
 Defaults to False.
- - `backend_type (schemas.BackendType, optional)`: Which mode to use.
+ - `backend_type (schemas.BackendType, optional)`: Which backend type to use.
 Possible values are `remote`, `docker` and `subprocess`.
-Defaults to `remote`.
+Defaults to `subprocess`.
 In `remote` mode, assets are registered on a deployed platform which also executes the tasks.
 In `subprocess` or `docker` mode, if no URL is given then all assets are created locally and tasks are
 executed locally. If a URL is given then the mode is a hybrid one: new assets are
@@ -36,7 +57,7 @@ Get the backend mode.
         
 ## temp_directory
 _This is a property._  
-Temporary directory for storing assets in debug mode.
+Temporary directory for storing assets in local mode.
         Deleted when the client is deleted.
         
 ## add_compute_plan

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -1,6 +1,6 @@
 # Client
 ```text
-Client(*, configuration_name: Optional[str] = None, configuration_file: Optional[pathlib.Path] = None, url: Optional[str] = None, token: Optional[str] = None, username: Optional[str] = None, password: Optional[str] = None, retry_timeout: Optional[int] = None, insecure: Optional[bool] = None, backend_type: Optional[substra.sdk.schemas.BackendType] = None)
+Client(*, client_name: Optional[str] = None, configuration_file: Optional[pathlib.Path] = None, url: Optional[str] = None, token: Optional[str] = None, username: Optional[str] = None, password: Optional[str] = None, retry_timeout: Optional[int] = None, insecure: Optional[bool] = None, backend_type: Optional[substra.sdk.schemas.BackendType] = None)
 ```
 
 Create a client.
@@ -8,15 +8,15 @@ Defaults to a subprocess client, suitable for development purpose.
 Configuration can be passed in the code, through environment variables or through a configuration file.
 The order of precedence is: values defined by the user in the code, environment variables, values read from the
 configuration file. If the attribute is not set, the value returned is None (and the origin is set to "default").
-In order to use configuration values not explicitly defined in the code, the parameter `configuration_name` must
+In order to use configuration values not explicitly defined in the code, the parameter `client_name` must
 not be None.
 
 **Arguments:**
- - `configuration_name (str, optional)`: Name of the configuration.
+ - `client_name (str, optional)`: Name of the client.
 Used to load relevant environment variables and select the right dictionary in the configuration file.
 Defaults to None.
  - `configuration_file (path, optional)`: Path to te configuration file.
-`configuration_name` must be defined too.
+`client_name` must be defined too.
 Defaults to None.
  - `url (str, optional)`: URL of the Substra platform.
 Mandatory to connect to a Substra platform. If no URL is given, all assets are created locally.

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -52,13 +52,13 @@ Asset creation specification base class.
 - status: Status
 - worker: str
 - rank: Optional[int]
-- inputs: List[InputRef]
-- outputs: Mapping[str, ComputeTaskOutput]
 - tag: str
 - creation_date: datetime
 - start_date: Optional[datetime]
 - end_date: Optional[datetime]
 - error_type: Optional[TaskErrorType]
+- inputs: List[InputRef]
+- outputs: Mapping[str, ComputeTaskOutput]
 ```
 
 ## Function

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "pydantic>=1.5.1",
         "six",
         "tqdm",
+        "python-slugify",
     ],
     python_requires=">=3.8",
     extras_require={

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -291,11 +291,11 @@ class Client:
             and self._token is None
             and not (config_dict["username"] is None or config_dict["password"] is None)
         ):
-            self._token = self.login(config_dict["username"].value, config_dict["password"].value)
             logger.info(
-                f"No token provided, getting one using username set in {config_dict['username'].origin}"
+                f"No token provided, getting one using username set in {config_dict['username'].origin} "
                 f"and password set in {config_dict['password'].origin}"
             )
+            self._token = self.login(config_dict["username"].value, config_dict["password"].value)
 
     def _get_backend(self, backend_type: schemas.BackendType):
         # Three possibilities:

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -3,6 +3,7 @@ import logging
 import os
 import pathlib
 import time
+import uuid
 from typing import List
 from typing import Optional
 from typing import Union
@@ -78,6 +79,7 @@ class Client:
 
     def __init__(
         self,
+        name: Optional[str] = None,
         url: Optional[str] = None,
         token: Optional[str] = None,
         retry_timeout: int = DEFAULT_RETRY_TIMEOUT,
@@ -86,6 +88,11 @@ class Client:
     ):
         self._retry_timeout = retry_timeout
         self._token = token
+
+        if name is None:
+            self.name = uuid.uuid4()
+        else:
+            self.name = name
 
         self._insecure = insecure
         self._url = url

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -4,7 +4,6 @@ import logging
 import os
 import pathlib
 import time
-import uuid
 from typing import Any
 from typing import Dict
 from typing import List
@@ -57,22 +56,50 @@ def logit(f):
     return wrapper
 
 
-def _get_env_var(attribute_name, client_name):
-    return f"SUBSTRA_{slugify(client_name).upper()}_{slugify(attribute_name).upper()}"
+def _upper_slug(s: str) -> str:
+    return slugify(s, separator="_").upper()
+
+
+def _get_env_var(attribute_name: str, configuration_name: str) -> str:
+    """
+    Returns the environment variable associated with a given attribute for a given Client,
+    identified by its configuration_name
+    """
+    return f"SUBSTRA_{_upper_slug(configuration_name)}_{_upper_slug(attribute_name)}"
 
 
 @dataclasses.dataclass
 class SettingValue:
     value: Any
-    origin: Literal["code", "environment", "config_file"]
+    origin: Literal["code", "environment_variable", "config_file", "default"]
 
 
-settings_precedence = ["code", "environment", "config_file"]
+def _get_config_value(
+    *,
+    attribute_name: str,
+    code_values: Dict[str, Any],
+    configuration_name: Optional[str],
+    client_config_dict: Dict[str, str],
+    mapping: Dict[str, callable],
+) -> SettingValue:
+    """
+    For a given attribute, return the value to be used in the Client configuration.
+    The order of precedence is: values defined by the user in the code, environment variables, values read from the
+    configuration file. If the attribute is not set, the value returned is None (and the origin is set to "default").
 
+    Args:
+        attribute_name (str): Name of the attribute for which we want to get the value to use
+        code_values (dict): Dictionary containing the values read from the code (or None)
+        configuration_name (str or None): Name of the configuration to use; it is used to determine which env var to use
+            and which sub-dictionary of the configuration file to consider; if None, only the values defined in the code
+            are considered.
+        client_config_dict (dict): Content of the configuration file
+        mapping (dict): Mapping associating a callable to each attribute; usually used for type conversion, but could be
+            used for more advanced processing
 
-def _get_config_value(attribute_name, code_values, client_name, client_config_dict) -> Optional[SettingValue]:
-    # Please ensure that the precedence coded by this function stays synchronized with the
-    # list above
+    Returns:
+        SettingValue: Object containing the value and its origin (code, environment_variable, config_file or default)
+    """
 
     # Some values are boolean that might be set to False, so we check explicitly "is not None"
     # Note that explicitly passing "None" in the code is equivalent to omitting it.
@@ -81,61 +108,106 @@ def _get_config_value(attribute_name, code_values, client_name, client_config_di
         return SettingValue(value=code_values[attribute_name], origin="code")
 
     # if client_name is not given, we cannot look through env var and config files
-    if not client_name:
-        return None
+    if not configuration_name:
+        return SettingValue(value=None, origin="default")
 
-    env_var_name = _get_env_var(attribute_name, client_name)
+    env_var_name = _get_env_var(attribute_name, configuration_name)
     # In environment variables, though, we never get "None"
     if env_var_name in os.environ:
-        return SettingValue(value=os.environ[env_var_name], origin="environment")
+        return SettingValue(value=mapping[attribute_name](os.environ[env_var_name]), origin="environment_variable")
 
     if attribute_name in client_config_dict:
-        return SettingValue(value=client_config_dict[attribute_name], origin="config_file")
+        return SettingValue(value=mapping[attribute_name](client_config_dict[attribute_name]), origin="config_file")
 
-    return None
+    return SettingValue(value=None, origin="default")
 
 
 def get_client_configuration(
     *,
     config_file: Optional[pathlib.Path],
-    client_name: Optional[str],
+    configuration_name: Optional[str],
     code_values: Dict[str, Any],
-) -> Dict[str, Optional[SettingValue]]:
+) -> Dict[str, SettingValue]:
+    """
+    Get the unified configuration values for a given client, out of three possible sources.
+    The order of precedence is: values defined by the user in the code, environment variables, values read from the
+    configuration file. If the attribute is not set, the value returned is None (and the origin is set to "default").
+
+    Args:
+        config_file (Path or None): Path to the yaml configuration file, if existing
+        configuration_name (str or None): Name of the configuration to use; it is used to determine which env var to use
+            and which sub-dictionary of the configuration file to consider; if None, only the values defined in the code
+            are considered.
+        code_values (dict): Value passed by the user directly in the code when instantiating the `Client`
+
+    Returns:
+     A dictionary associating each attribute with its `SettingValue` (containing the actual value and its origin)
+
+    """
     if config_file and config_file.exists():
         config_dict = yaml.safe_load(config_file.read_text())
     else:
         config_dict = {}
+
+    values_mapping = {
+        "url": str,
+        "token": str,
+        "username": str,
+        "password": str,
+        "retry_timeout": int,
+        "insecure": bool,
+        "backend_type": schemas.BackendType,
+    }
     return {
         attribute_name: _get_config_value(
             attribute_name=attribute_name,
             code_values=code_values,
-            client_name=client_name,
-            client_config_dict=config_dict.get(client_name, {}),
+            configuration_name=configuration_name,
+            client_config_dict=config_dict.get(configuration_name, {}),
+            mapping=values_mapping,
         )
-        for attribute_name in code_values
+        for attribute_name in values_mapping
     }
 
 
 class Client:
-    """Create a client
+    """Create a client.
+    Defaults to a subprocess client, suitable for development purpose.
+    Configuration can be passed in the code, through environment variables or through a configuration file.
 
     Args:
-        url (str, optional): URL of the Substra platform. Mandatory
-            to connect to a Substra platform. If no URL is given debug must be True and all
+        configuration_name (str, optional): Name of the configuration.
+            Used to load relevant environment variables and select the right dictionary in the configuration file.
+            If None, configuration values will only be read from the code, or default will be used.
+            Defaults to None.
+        configuration_file (path, optional): Path to te configuration file.
+            `configuration_name` must be defined too.
+            Defaults to None.
+        url (str, optional): URL of the Substra platform.
+            Mandatory to connect to a Substra platform. If no URL is given debug must be True and all
             assets must be created locally.
             Defaults to None.
         token (str, optional): Token to authenticate to the Substra platform.
-            If no token is given, use the 'login' function to authenticate.
+            If no token is given, and a `username`/ `password` pair is provided,  the Client will try to authenticate
+            using 'login' function. It's always possible to generate a new token later by making another call to the
+            `login` function.
             Defaults to None.
-        retry_timeout (int, optional): Number of seconds before attempting a retry call in case
-            of timeout.
+        username (str, optional): Username to authenticate to the Substra platform.
+            Used in conjunction with a password to generate a token if not given, using the `login` function.
+            Not stored.
+            Defaults to None.
+        password (str, optional): Password to authenticate to the Substra platform.
+            Used in conjunction with an username to generate a token if not given, using the `login` function.
+            Not stored.
+            Defaults to None.
+        retry_timeout (int, optional): Number of seconds before attempting a retry call in case of timeout.
             Defaults to 5 minutes.
-        insecure (bool, optional): If True, the client can call a not-certified backend. This is
-            for development purposes.
+        insecure (bool, optional): If True, the client can call a not-certified backend.
+            This is for development purposes.
             Defaults to False.
-        backend_type (schemas.BackendType, optional): Which mode to use.
+        backend_type (schemas.BackendType, optional): Which backend type to use.
             Possible values are `remote`, `docker` and `subprocess`.
-            Defaults to `remote`.
+            Defaults to `subprocess`.
             In `remote` mode, assets are registered on a deployed platform which also executes the tasks.
             In `subprocess` or `docker` mode, if no URL is given then all assets are created locally and tasks are
             executed locally. If a URL is given then the mode is a hybrid one: new assets are
@@ -143,11 +215,10 @@ class Client:
             and tasks are executed locally.
     """
 
-    # TODO update docstring
-
     def __init__(
         self,
-        name: Optional[str] = None,
+        *,
+        configuration_name: Optional[str] = None,
         configuration_file: Optional[pathlib.Path] = None,
         url: Optional[str] = None,
         token: Optional[str] = None,
@@ -157,6 +228,9 @@ class Client:
         insecure: Optional[bool] = None,
         backend_type: Optional[schemas.BackendType] = None,
     ):
+        if configuration_file and not configuration_name:
+            logger.info("Configuration file ignored because no `configuration_name` was given.")
+
         code_values = {
             "url": url,
             "token": token,
@@ -167,28 +241,39 @@ class Client:
             "backend_type": backend_type,
         }
         config_dict = get_client_configuration(
-            client_name=name, config_file=configuration_file, code_values=code_values
+            configuration_name=configuration_name, config_file=configuration_file, code_values=code_values
         )
-
-        if name is None:
-            self.name = uuid.uuid4()
-        else:
-            self.name = name
-
-        if config_dict["retry_timeout"] is not None:
-            self._retry_timeout = int(config_dict["retry_timeout"].value)
-        else:
-            self._retry_timeout = DEFAULT_RETRY_TIMEOUT
-
-        self._insecure = bool(config_dict["insecure"].value) if config_dict["insecure"] is not None else False
-
-        if config_dict["backend_type"] is None:
+        if config_dict["backend_type"].value is None:
+            logger.info("No backend type specified, defaulting to subprocess")
             backend_type = schemas.BackendType.LOCAL_SUBPROCESS
         else:
             backend_type = config_dict["backend_type"].value
+            logger.info(f"Backend type set to {backend_type}, " f"as defined in {config_dict['backend_type'].origin}")
 
-        self._url = config_dict["url"].value if config_dict["url"] is not None else None
-        self._token = config_dict["token"].value if config_dict["token"] is not None else None
+        self._url = config_dict["url"].value
+        logger.info(f"The parameter `url` has been set to {self._url} " f"as defined in {config_dict['url'].origin} ")
+
+        self._token = config_dict["token"].value
+        if self._token:
+            logger.info(f"Token read from {config_dict['token'].origin}")
+
+        self._retry_timeout = (
+            config_dict["retry_timeout"].value
+            if config_dict["retry_timeout"].value is not None
+            else DEFAULT_RETRY_TIMEOUT
+        )
+        logger.info(
+            f"The parameter `retry_timeout` has been set to {self._retry_timeout} "
+            f"as defined in {config_dict['retry_timeout'].origin} "
+        )
+
+        self._insecure = config_dict["insecure"].value if config_dict["insecure"].value is not None else False
+
+        logger.info(
+            f"The parameter `insecure` has been set to {self._insecure} "
+            f"as defined in {config_dict['insecure'].origin} "
+        )
+
         self._backend = self._get_backend(backend_type)
         if (
             self._url
@@ -196,6 +281,10 @@ class Client:
             and not (config_dict["username"] is None or config_dict["password"] is None)
         ):
             self._token = self.login(config_dict["username"].value, config_dict["password"].value)
+            logger.info(
+                f"No token provided, getting one using username set in {config_dict['username'].origin}"
+                f"and password set in {config_dict['password'].origin}"
+            )
 
     def _get_backend(self, backend_type: schemas.BackendType):
         # Three possibilities:

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -82,7 +82,7 @@ class Client:
         token: Optional[str] = None,
         retry_timeout: int = DEFAULT_RETRY_TIMEOUT,
         insecure: bool = False,
-        backend_type: schemas.BackendType = schemas.BackendType.REMOTE,
+        backend_type: schemas.BackendType = schemas.BackendType.LOCAL_SUBPROCESS,
     ):
         self._retry_timeout = retry_timeout
         self._token = token

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -142,6 +142,12 @@ class BadLoginException(RequestException):
     pass
 
 
+class ConfigurationInfoError(SDKException):
+    """ConfigurationInfoError"""
+
+    pass
+
+
 class BadConfiguration(SDKException):
     """Bad configuration"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def pytest_configure(config):
 
 @pytest.fixture
 def client(tmpdir):
-    c = substra.Client(url="http://foo.io")
+    c = substra.Client(url="http://foo.io", backend_type="remote")
     return c
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def pytest_configure(config):
 
 @pytest.fixture
 def client(tmpdir):
-    c = substra.Client(url="http://foo.io", backend_type="remote")
+    c = substra.Client(url="http://foo.io", backend_type="remote", token="foo")
     return c
 
 

--- a/tests/sdk/local/test_debug.py
+++ b/tests/sdk/local/test_debug.py
@@ -33,7 +33,7 @@ def test_get_backend_type_subprocess(subprocess_clients):
 
 
 def test_get_backend_type_remote():
-    client = substra.Client(url="foo.com")
+    client = substra.Client(url="foo.com", backend_type="remote")
     assert client.backend_mode == substra.BackendType.REMOTE
 
 

--- a/tests/sdk/local/test_debug.py
+++ b/tests/sdk/local/test_debug.py
@@ -33,7 +33,7 @@ def test_get_backend_type_subprocess(subprocess_clients):
 
 
 def test_get_backend_type_remote():
-    client = substra.Client(url="foo.com", backend_type="remote")
+    client = substra.Client(url="foo.com", backend_type="remote", token="foo")
     assert client.backend_mode == substra.BackendType.REMOTE
 
 

--- a/tests/sdk/test_archive.py
+++ b/tests/sdk/test_archive.py
@@ -12,7 +12,6 @@ from substra.sdk.archive.safezip import ZipFile
 
 
 class TestsZipFile:
-
     # This zip file was specifically crafted and contains empty files named:
     # foo/bar
     # ../foo/bar
@@ -68,7 +67,6 @@ class TestsTarSafe:
 
     def test_raise_on_symlink(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-
             # create the following tree structure:
             # ./Dockerfile
             # ./foo

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -1,0 +1,45 @@
+import pytest
+
+from substra.sdk import schemas
+from substra.sdk.client import Client
+
+
+@pytest.fixture
+def dummy_rest_client():
+    class DummyRestClient:
+        def __init__(self, url):
+            self.url = url
+
+        def login(self, username, password):
+            if self.url == "example1.com":
+                return "token1"
+            if self.url == "example2.com":
+                return "token2"
+            if self.url == "example3.com":
+                return "token3"
+
+    def get_rest_client(url):
+        return DummyRestClient(url)
+
+    return get_rest_client
+
+
+def test_default_client():
+    client = Client()
+    assert client.backend_mode == schemas.BackendType.LOCAL_SUBPROCESS
+    assert client.name is not None
+
+
+@pytest.mark.parametrize(
+    ["mode", "name", "url", "token", "insecure", "retry_timeout"],
+    [
+        ("subprocess", "foo", None, None, True, 5),
+        ("docker", "foobar", None, None, True, None),
+        ("remote", "bar", "example.com", "bloop", False, 15),
+    ],
+)
+def test_client_configured_in_code(mode, name, url, token, insecure, retry_timeout):
+    client = Client(backend_type=mode, name=name, url=url, token=token, insecure=insecure, retry_timeout=retry_timeout)
+    assert client.name == name
+    # assert client.backend_mode == schemas.BackendType.LOCAL_SUBPROCESS
+    # assert client._backend._client.token == token if token is not None

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -6,6 +6,30 @@ from substra.sdk.client import Client
 from substra.sdk.client import _upper_slug
 
 
+@pytest.fixture
+def config_file(tmp_path):
+    config_dict = {
+        "toto": {
+            "backend_type": "remote",
+            "url": "toto-org.com",
+            "username": "toto_file_username",
+            "password": "toto_file_password",
+        }
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config_dict))
+    return config_file
+
+
+def stub_login(username, password):
+    if username == "org-1" and password == "password1":
+        return "token1"
+    if username == "env_var_username" and password == "env_var_password":
+        return "env_var_token"
+    if username == "toto_file_username" and password == "toto_file_password":
+        return "toto_file_token"
+
+
 @pytest.mark.parametrize(
     ["input", "expected"],
     [
@@ -29,6 +53,7 @@ def test_default_client():
         (schemas.BackendType.LOCAL_SUBPROCESS, "foo", None, None, True, 5),
         (schemas.BackendType.LOCAL_DOCKER, "foobar", None, None, True, None),
         (schemas.BackendType.REMOTE, "bar", "example.com", "bloop", False, 15),
+        (schemas.BackendType.REMOTE, "hybrid", "example.com", "foo", True, 500),
     ],
 )
 def test_client_configured_in_code(mode, configuration_name, url, token, insecure, retry_timeout):
@@ -50,22 +75,16 @@ def test_client_configured_in_code(mode, configuration_name, url, token, insecur
         assert client._token == token
     else:
         assert client._token is None
-
-
-def stub_login(username, password):
-    if username == "org-1" and password == "password1":
-        return "token1"
-    if username == "env_var_username" and password == "env_var_password":
-        return "env_var_token"
-    if username == "org-3" and password == "toto_file_password":
-        return "toto_file_username"
+    if url is not None:
+        assert client._url == url
+    else:
+        assert client._url is None
 
 
 def test_client_with_password(mocker):
     mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
     client = Client(
         backend_type="remote",
-        configuration_name="toto",
         url="example.com",
         token=None,
         username="org-1",
@@ -74,33 +93,96 @@ def test_client_with_password(mocker):
     assert client._token == "token1"
 
 
-@pytest.fixture
-def config_file(tmp_path):
-    config_dict = {
-        "toto": {
-            "url": "toto-org.com",
-            "username": "toto_file_username",
-            "password": "toto_file_password",
-        }
-    }
-    config_file = tmp_path / "config.yaml"
-    config_file.write_text(yaml.dump(config_dict))
-    return config_file
+def test_client_token_supercedes_password(mocker):
+    mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
+    client = Client(
+        backend_type="remote",
+        url="example.com",
+        token="token0",
+        username="org-1",
+        password="password1",
+    )
+    assert client._token == "token0"
 
 
-def test_client_config_env_overrides_config_file(mocker, monkeypatch, config_file):
+def test_client_configuration_from_env_var(mocker, monkeypatch):
+    mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
+    monkeypatch.setenv("SUBSTRA_TOTO_BACKEND_TYPE", "remote")
+    monkeypatch.setenv("SUBSTRA_TOTO_URL", "toto-org.com")
+    monkeypatch.setenv("SUBSTRA_TOTO_USERNAME", "env_var_username")
+    monkeypatch.setenv("SUBSTRA_TOTO_PASSWORD", "env_var_password")
+    monkeypatch.setenv("SUBSTRA_TOTO_RETRY_TIMEOUT", "42")
+    monkeypatch.setenv("SUBSTRA_TOTO_INSECURE", "true")
+    client = Client(configuration_name="toto")
+    assert client.backend_mode == "remote"
+    assert client._url == "toto-org.com"
+    assert client._token == "env_var_token"
+    assert client._retry_timeout == 42
+    assert client._insecure is True
+
+
+def test_client_configuration_from_config_file(mocker, config_file):
+    mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
+    client = Client(configuration_file=config_file, configuration_name="toto")
+    assert client.backend_mode == "remote"
+    assert client._url == "toto-org.com"
+    assert client._token == "toto_file_token"
+    assert client._retry_timeout == 300
+    assert client._insecure is False
+
+
+def test_client_configuration_code_overrides_env_var(monkeypatch):
+    """
+    A variable set in the code overrides one set in an env variable
+    """
+    monkeypatch.setenv("SUBSTRA_TOTO_BACKEND_TYPE", "remote")
+    monkeypatch.setenv("SUBSTRA_TOTO_URL", "toto-org.com")
+    monkeypatch.setenv("SUBSTRA_TOTO_USERNAME", "env_var_username")
+    monkeypatch.setenv("SUBSTRA_TOTO_PASSWORD", "env_var_password")
+    monkeypatch.setenv("SUBSTRA_TOTO_RETRY_TIMEOUT", "42")
+    monkeypatch.setenv("SUBSTRA_TOTO_INSECURE", "true")
+    client = Client(
+        configuration_name="toto",
+        backend_type="subprocess",
+        token="foobar",
+    )
+    assert client.backend_mode == "subprocess"
+    assert client._url == "toto-org.com"
+    assert client._token == "foobar"
+    assert client._retry_timeout == 42
+    assert client._insecure is True
+
+
+def test_client_configuration_code_overrides_config_file(mocker, config_file):
+    """
+    A variable set in the code overrides one set in a config file
+    """
+    mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
+    client = Client(
+        configuration_name="toto",
+        configuration_file=config_file,
+        username="org-1",
+        password="password1",
+        retry_timeout=100,
+    )
+    assert client.backend_mode == "remote"
+    assert client._url == "toto-org.com"
+    assert client._token == "token1"
+    assert client._retry_timeout == 100
+    assert client._insecure is False
+
+
+def test_client_configuration_env_var_overrides_config_file(mocker, monkeypatch, config_file):
     """
     A variable set in an env var overrides one set in a config file
     """
     mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
+    monkeypatch.setenv("SUBSTRA_TOTO_BACKEND_TYPE", "docker")
     monkeypatch.setenv("SUBSTRA_TOTO_USERNAME", "env_var_username")
     monkeypatch.setenv("SUBSTRA_TOTO_PASSWORD", "env_var_password")
-    client = Client(
-        configuration_file=config_file,
-        backend_type="remote",
-        configuration_name="toto",
-        url=None,
-        token=None,
-    )
+    client = Client(configuration_file=config_file, configuration_name="toto", retry_timeout=12)
+    assert client.backend_mode == "docker"
     assert client._url == "toto-org.com"
     assert client._token == "env_var_token"
+    assert client._retry_timeout == 12
+    assert client._insecure is False

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -144,11 +144,11 @@ def test_client_configuration_code_overrides_env_var(monkeypatch):
     client = Client(
         configuration_name="toto",
         backend_type="subprocess",
-        token="foobar",
+        url="",
     )
     assert client.backend_mode == "subprocess"
-    assert client._url == "toto-org.com"
-    assert client._token == "foobar"
+    assert client._url == ""
+    assert client._token is None
     assert client._retry_timeout == 42
     assert client._insecure is True
 

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -1,4 +1,5 @@
 import pytest
+import yaml
 
 from substra.sdk import schemas
 from substra.sdk.client import Client
@@ -41,5 +42,62 @@ def test_default_client():
 def test_client_configured_in_code(mode, name, url, token, insecure, retry_timeout):
     client = Client(backend_type=mode, name=name, url=url, token=token, insecure=insecure, retry_timeout=retry_timeout)
     assert client.name == name
-    # assert client.backend_mode == schemas.BackendType.LOCAL_SUBPROCESS
-    # assert client._backend._client.token == token if token is not None
+    assert client.backend_mode == mode
+    assert client._insecure == insecure
+    if retry_timeout is not None:
+        assert client._retry_timeout == retry_timeout
+    else:
+        assert client._retry_timeout == 300
+    if token is not None:
+        assert client._token == token
+    else:
+        assert client._token is None
+
+
+def stub_login(username, password):
+    if username == "org-1" and password == "password1":
+        return "token1"
+    if username == "env_var_username" and password == "env_var_password":
+        return "env_var_token"
+    if username == "org-3" and password == "toto_file_password":
+        return "toto_file_username"
+
+
+def test_client_with_password(mocker):
+    mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
+    client = Client(
+        backend_type="remote", name="toto", url="example.com", token=None, username="org-1", password="password1"
+    )
+    assert client._token == "token1"
+
+
+@pytest.fixture
+def config_file(tmp_path):
+    config_dict = {
+        "toto": {
+            "url": "toto-org.com",
+            "username": "toto_file_username",
+            "password": "toto_file_password",
+        }
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config_dict))
+    return config_file
+
+
+def test_client_config_env_overrides_config_file(mocker, monkeypatch, config_file):
+    """
+    A variable set in an env var overrides one set in a config file
+    """
+    mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
+    monkeypatch.setenv("SUBSTRA_TOTO_USERNAME", "env_var_username")
+    monkeypatch.setenv("SUBSTRA_TOTO_PASSWORD", "env_var_password")
+    client = Client(
+        configuration_file=config_file,
+        backend_type="remote",
+        name="toto",
+        url=None,
+        token=None,
+    )
+    assert client._url == "toto-org.com"
+    assert client._token == "env_var_token"

--- a/tests/sdk/test_config.py
+++ b/tests/sdk/test_config.py
@@ -72,7 +72,7 @@ def test_from_config_file_fail(tmpdir):
 
 def test_login_remote_without_url(tmpdir):
     with pytest.raises(substra.exceptions.SDKException):
-        substra.Client()
+        substra.Client(backend_type="remote")
 
 
 def test_token_without_tokens_path(tmpdir):

--- a/tests/sdk/test_rest_client.py
+++ b/tests/sdk/test_rest_client.py
@@ -97,7 +97,7 @@ def test_add_wrong_url(mocker):
     error = json.decoder.JSONDecodeError("", "", 0)
 
     mock_requests(mocker, "post", status=200, json_error=error)
-    test_client = Client(url="http://www.dummy.com")
+    test_client = Client(url="http://www.dummy.com", token="foo")
     with pytest.raises(exceptions.BadConfiguration) as e:
         test_client.login("test_client", "hehe")
     assert "Make sure that given url" in e.value.args[0]


### PR DESCRIPTION
## Summary
This PR add the option to configure a Substra client using a configuration file or environment variables. 

The priority order is values given in code (override everything else) > values in environment variables > values in configuration file > default values. 

If both a token and a pair username / password are provided (by any means), the token will always be used. If a token is not provided, one will be generated from the username / password if appropriate (remote or hybrid client). 
It is also possible to regenerate a token by an explicit call to the `login` method.

This PR can be reviewed commit by commit.

## Notes
It's a breaking change because the default (client instantiated with no parameter) will be a local subprocess client instead of a remote client. This decision was taken because the subprocess mode requires no additional configuration, whereas a remote client requires at least an url and a means of authenticating. 

During the implementation, the following decisions have been taken:
- This PR adds a `name` argument to the `Client` class: it is required to be able to match other configurations values (url, username, ...) to a given client when we define several clients in a same script (which is almost all the time in Substra).
- It does NOT use [Pydantic Settings](https://docs.pydantic.dev/usage/settings/): Pydantic has an opinionated, if reasonable, take on settings, and it does not match exactly our needs (in particular regarding the fact that we need dynamical nested configuration for defining several clients at the same time); rather than using hacks to get Pydantic to do what we need, I decided to start from scratch.
- All the configuration occurs in the `__init__`, and not as a `classmethod` that would return an object from a file or a set of variable environments: the configuration options should be seamless from the end user perspective, and switching partially to one option or the other should encourage best security practices (i.e. never storing a password in code or in a file, but only in an env var).
- If a token is provided, it will used over other means of authenticating. 
- The option to create a client from [profiles files created from the CLI](https://github.com/Substra/substra/blob/117a9158dd5abf188c53b9d4553b1ace15a25596/substra/sdk/config.py) is kept as is; it has not been removed, but it also hasn't been reused nor unified with the current work done in this PR. The status of the CLI is still under question, so it was thought best to keep both separated.


Any of the decision above can of course be amended depending on the feedback.

## Open questions
1. Where to we want to convert values to their appropriate type? 
   a. When they are read, using a dict matching each value to its correct type
   b. In the `__init__`, when the values are assigned to attributes
2. Do we want explicit assignation, allowing for finer control on attributes settings, or do we prefer fewer code lines with some "magic" using `setattr`?




## Remaining TODO
- [x] Update doctrings
- [x] Add logging to give the user information about which source was used for configuring each parameter
- [x] Add unit tests
- [x] Check where the organisation name / id is set in the Remote Client and see if we want to unify both usage
- [x] Update user documentation
- [x] Update tutorials 

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [x] [substra-tests](https://github.com/Substra/substra-tests) https://github.com/Substra/substra-tests/pull/253
  - [x] [substrafl](https://github.com/Substra/substrafl) https://github.com/Substra/substrafl/pull/119
  - [x] [substra-documentation](https://github.com/Substra/substra-documentation) https://github.com/Substra/substra-documentation/pull/305
