### PR TITLE
chore: update performance view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - BREAKING: default backend type for Client is now "subprocess" ([#353](https://github.com/Substra/substra/pull/353))
-- Add identifier to performance view when calling `client.get_performances` ([#197](https://github.com/Substra/orchestrator/pull/197))
+- Add identifier to performance view when calling `client.get_performances` ([#357](https://github.com/Substra/substra/pull/357))
 
 ## [0.43.0](https://github.com/Substra/substra/releases/tag/0.43.0) - 2023-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - BREAKING: default backend type for Client is now "subprocess" ([#353](https://github.com/Substra/substra/pull/353))
+- Add identifier to performance view when calling `client.get_performances` ([#197](https://github.com/Substra/orchestrator/pull/197))
 
 ## [0.43.0](https://github.com/Substra/substra/releases/tag/0.43.0) - 2023-03-31
 

--- a/substra/sdk/backends/local/dal.py
+++ b/substra/sdk/backends/local/dal.py
@@ -137,6 +137,7 @@ class DataAccess:
                     performances.function_name.append(function.name)
                     performances.task_rank.append(task.rank)
                     performances.round_idx.append(task.metadata.get("round_idx"))
+                    performances.identifier.append(perf_identifier)
                     performances.performance.append(task.outputs[perf_identifier].value)
 
         return performances

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -68,7 +68,7 @@ class Remote(base.BaseBackend):
             performances.function_name.append(test_task["metric"]["name"])
             performances.task_rank.append(test_task["compute_task"]["rank"])
             performances.round_idx.append(test_task["compute_task"]["round_idx"])
-            performances.round_idx.append(test_task["identifier"])
+            performances.identifier.append(test_task["identifier"])
             performances.performance.append(test_task["perf"])
 
         return performances

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -68,6 +68,7 @@ class Remote(base.BaseBackend):
             performances.function_name.append(test_task["metric"]["name"])
             performances.task_rank.append(test_task["compute_task"]["rank"])
             performances.round_idx.append(test_task["compute_task"]["round_idx"])
+            performances.round_idx.append(test_task["identifier"])
             performances.performance.append(test_task["perf"])
 
         return performances

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -354,6 +354,7 @@ class Performances(_Model):
     function_name: List[str] = []
     task_rank: List[int] = []
     round_idx: List[int] = []
+    identifier: List[str] = []
     performance: List[float] = []
 
 

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -582,6 +582,7 @@ COMPUTE_PLAN_PERF = {
                 "key": "e526243f-f51a-4737-9fea-a5d55f4205fe",
                 "name": "accuracy",
             },
+            "identifier": "performance",
             "perf": 0.673,
         },
         {
@@ -602,6 +603,7 @@ COMPUTE_PLAN_PERF = {
                 "key": "e526243f-f51a-4737-9fea-a5d55f4205fe",
                 "name": "accuracy",
             },
+            "identifier": "performance",
             "perf": 0.834,
         },
         {
@@ -622,6 +624,7 @@ COMPUTE_PLAN_PERF = {
                 "key": "e526243f-f51a-4737-9fea-a5d55f4205fe",
                 "name": "accuracy",
             },
+            "identifier": "performance",
             "perf": 0.956,
         },
     ],


### PR DESCRIPTION
# Description

Performance asset were unique regarding their compute task key, and the function key they were computed from. Or, we want to have the possibility to have a function that outputs several performance and store them in the same task.

This implies two main things:
   - Performance are now unique regarding the compute task key, the function key AND the output identifier
   - The frontend must serialize regarding the identifier, and not the function key

The PR batch modify both the orchestrator and backend db in order to include the identifier as an additional unique condition.
In the backend, we use the ComputeTaskOutput as primary key directly.

## Companion PR

- https://github.com/Substra/substra-backend/pull/634
- https://github.com/Substra/substra-tests/pull/251 (main)
- https://github.com/Substra/orchestrator/pull/197
- https://github.com/Substra/substra-frontend/pull/194
- https://github.com/Substra/substra/pull/357

## E2E tests
- https://github.com/owkin/substra-ci/actions/runs/4872054802