### PR TITLE
feat: deprecate input output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [pep8-naming, flake8-bugbear]
-        args: ['--classmethod-decorators=classmethod,validator']
+        args: ['--classmethod-decorators=classmethod,validator,root_validator']
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [pep8-naming, flake8-bugbear]
+        args: ['--classmethod-decorators=classmethod,validator']
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `InputAsset` and `OutputAsset` ([#361](https://github.com/Substra/substra/pull/361))
+- Concepts `InputAsset` and `OutputAsset` have been introduced, mirroring concept in `substra-backend`([#361](https://github.com/Substra/substra/pull/361))
 - Utils to get `input / output assets` for a specific task (`get_task_output_asset`, `list_task_output_assets`, `list_task_input_assets`) ([#361](https://github.com/Substra/substra/pull/361))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `InputAsset` and `OutputAsset` ([#361](https://github.com/Substra/substra/pull/361))
+- Utils to get `input / output assets` for a specific task (`get_task_output_asset`, `list_task_output_assets`, `list_task_input_assets`) ([#361](https://github.com/Substra/substra/pull/361))
+
+### Changed
+
+- `Task`(including `inputs` and `outputs` without linked assets) replace `SummaryTask` ([#361](https://github.com/Substra/substra/pull/361))
+
+### Removed
+
+ - `SummaryTask` ([#361](https://github.com/Substra/substra/pull/361))
+
 ## [0.44.0](https://github.com/Substra/substra/releases/tag/0.44.0) - 2023-05-11
 
 ### Added

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -82,9 +82,9 @@ class Local(base.BaseBackend):
             schemas.Type.OutputAsset, {"identifier": identifier, "compute_task_key": compute_task_key}
         )
         if len(outputs) == 0:
-            raise ValueError("Expecting one asset, found none")
+            raise exceptions.TaskAssetNotFoundError(compute_task_key=compute_task_key, identifier=identifier)
         elif len(outputs) > 1:
-            raise ValueError(f"Expecting one asset, found {outputs}")
+            raise exceptions.TaskAssetMultipleFoundError(compute_task_key=compute_task_key, identifier=identifier)
 
         return outputs[0]
 

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -408,12 +408,10 @@ class Local(base.BaseBackend):
             worker=spec.worker,
             compute_plan_key=compute_plan_key,
             rank=rank,
-            
             tag=spec.tag or "",
             status=models.Status.waiting,
             metadata=spec.metadata if spec.metadata else dict(),
         )
-
 
         task = self._db.add(task)
         self._worker.schedule_task(task, spec)
@@ -587,4 +585,4 @@ def _output_from_spec(outputs: Dict[str, schemas.ComputeTaskOutputSpec]) -> Dict
 def _warn_on_transient_outputs(outputs: typing.Dict[str, schemas.ComputeTaskOutputSpec]):
     for _, output in outputs.items():
         if output.is_transient:
-            warnings.warn("`transient=True` is ignored in local mode")
+            warnings.warn("`transient=True` is ignored in local mode", stacklevel=1)

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -77,7 +77,7 @@ class Local(base.BaseBackend):
     def get(self, asset_type, key):
         return self._db.get(asset_type, key)
 
-    def get_output_asset(self, compute_task_key: str, identifier: str) -> models.OutputAsset:
+    def get_task_output_asset(self, compute_task_key: str, identifier: str) -> models.OutputAsset:
         outputs = self._db.list(
             schemas.Type.OutputAsset, {"identifier": identifier, "compute_task_key": compute_task_key}
         )
@@ -418,13 +418,15 @@ class Local(base.BaseBackend):
             worker=spec.worker,
             compute_plan_key=compute_plan_key,
             rank=rank,
+            inputs=spec.inputs,
+            outputs=_output_from_spec(spec.outputs),
             tag=spec.tag or "",
             status=models.Status.waiting,
             metadata=spec.metadata if spec.metadata else dict(),
         )
 
         task = self._db.add(task)
-        self._worker.schedule_task(task, spec)
+        self._worker.schedule_task(task)
         return task
 
     def _check_inputs_outputs(self, spec, function_key):

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -389,11 +389,6 @@ class Local(base.BaseBackend):
         compute_plan = self.__execute_compute_plan(spec, compute_plan, visited, tasks, spec_options)
         return compute_plan
 
-    def _add_output_assets(self, output_specs: Dict[str, schemas.ComputeTaskOutputSpec]):
-
-         for identifier, output in outputs.items():
-            self._db.add(schemas.Type.ComputeTaskOutputAsset)
-            pass
     def _add_task(self, key, spec, spec_options=None):
         self._check_metadata(spec.metadata)
         self._check_data_samples(spec)

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -81,9 +81,10 @@ class Local(base.BaseBackend):
         outputs = self._db.list(
             schemas.Type.OutputAsset, {"identifier": identifier, "compute_task_key": compute_task_key}
         )
-
-        if len(outputs) != 1:
-            raise ValueError("Expecting only one asset")
+        if len(outputs) == 0:
+            raise ValueError("Expecting one asset, found none")
+        elif len(outputs) > 1:
+            raise ValueError(f"Expecting one asset, found {outputs}")
 
         return outputs[0]
 

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -85,7 +85,17 @@ class Local(base.BaseBackend):
         if len(outputs) != 1:
             raise ValueError("Expecting only one asset")
 
+        return outputs[0]
+
+    def list_task_output_assets(self, compute_task_key: str) -> List[models.OutputAsset]:
+        outputs = self._db.list(schemas.Type.OutputAsset, {"compute_task_key": compute_task_key})
+
         return outputs
+
+    def list_task_input_assets(self, compute_task_key: str) -> List[models.InputAsset]:
+        inputs = self._db.list(schemas.Type.InputAsset, {"compute_task_key": compute_task_key})
+
+        return inputs
 
     def get_performances(self, key):
         performances = self._db.get_performances(key)

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -198,8 +198,10 @@ class Worker:
 
     def _save_output(
         self,
+        *,
         task,
         function_output: models.FunctionOutput,
+        permissions: schemas.Permissions,
         output_id_filename: Dict[str, str],
         output_volume: str,
         function_key: str,
@@ -226,8 +228,7 @@ class Worker:
                 ),
                 creation_date=datetime.datetime.now(),
                 owner=task.owner,
-                # TODO: Fix
-                permissions=models.Permissions(process=models.Permission(public=True, authorized_ids=["all"])),
+                permissions=models.Permissions(process=permissions),
             )
             self._db.add(value)
         else:
@@ -341,9 +342,11 @@ class Worker:
             # Save the outputs
             update_live_performances = False
             for function_output in function.outputs:
+                permissions = specs.outputs[function_output.identifier].permissions
                 update_live_performances = self._save_output(
                     task=task,
                     function_output=function_output,
+                    permissions=permissions,
                     output_id_filename=output_id_filename,
                     output_volume=volumes[VOLUME_OUTPUTS],
                     function_key=function.key,

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -29,6 +29,7 @@ from substra.sdk.backends.local.compute.spawner.base import VOLUME_OUTPUTS
 TPL_VOLUME_INPUTS = "${" + VOLUME_INPUTS + "}"
 TPL_VOLUME_OUTPUTS = "${" + VOLUME_OUTPUTS + "}"
 
+
 class TaskResource(dict):
     def __init__(self, id: str, value: str, multiple: bool):
         super().__init__(self, id=id, value=value, multiple=multiple)
@@ -226,11 +227,11 @@ class Worker:
                 creation_date=datetime.datetime.now(),
                 owner=task.owner,
                 # TODO: Fix
-                permissions = models.Permissions(process=models.Permission(public=True, authorized_ids=["all"]))
+                permissions=models.Permissions(process=models.Permission(public=True, authorized_ids=["all"])),
             )
-            self._db.add(value)    
+            self._db.add(value)
         else:
-            raise ValueError(f"This asset kind is not supported for function output: {function_output.kind}") 
+            raise ValueError(f"This asset kind is not supported for function output: {function_output.kind}")
         output_asset = models.OutputAsset(
             key=str(uuid.uuid4()),
             kind=function_output.kind,

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -20,6 +20,7 @@ from substra.sdk import fs
 from substra.sdk import models
 from substra.sdk import schemas
 from substra.sdk.backends.local import dal
+from substra.sdk.backends.local import models as models_local
 from substra.sdk.backends.local.compute import spawner
 from substra.sdk.backends.local.compute.spawner import BaseSpawner
 from substra.sdk.backends.local.compute.spawner.base import VOLUME_CLI_ARGS
@@ -233,8 +234,7 @@ class Worker:
             self._db.add(value)
         else:
             raise ValueError(f"This asset kind is not supported for function output: {function_output.kind}")
-        output_asset = models.OutputAsset(
-            key=str(uuid.uuid4()),
+        output_asset = models_local.OutputAssetDb(
             kind=function_output.kind,
             identifier=function_output.identifier,
             asset=value,

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -29,7 +29,6 @@ from substra.sdk.backends.local.compute.spawner.base import VOLUME_OUTPUTS
 TPL_VOLUME_INPUTS = "${" + VOLUME_INPUTS + "}"
 TPL_VOLUME_OUTPUTS = "${" + VOLUME_OUTPUTS + "}"
 
-
 class TaskResource(dict):
     def __init__(self, id: str, value: str, multiple: bool):
         super().__init__(self, id=id, value=value, multiple=multiple)
@@ -215,19 +214,7 @@ class Worker:
 
         if function_output.kind == schemas.AssetKind.performance:
             update_live_performances = True
-            perf = json.loads(output_path.read_text())["all"]
-            value = perf
-            print(value)
-             print("_save_output value", value)
-        output_asset = models.OutputAsset(
-            kind=function_output.kind,
-            identifier=function_output.identifier,
-            asset=value,
-            compute_task_key=task.key,
-        )
-       
-        print("_save_output output_asset", output_asset)
-        self._db.add(output_asset)
+            value = json.loads(output_path.read_text())["all"]
         elif function_output.kind == schemas.AssetKind.model:
             value = models.OutModel(
                 key=str(uuid.uuid4()),
@@ -241,20 +228,16 @@ class Worker:
                 # TODO: Fix
                 permissions = models.Permissions(process=models.Permission(public=True, authorized_ids=["all"]))
             )
-            print(value)
-            self._db.add(value)
-            
+            self._db.add(value)    
         else:
-            raise ValueError(f"This asset kind is not supported for function output: {function_output.kind}")
-        print("_save_output value", value)
+            raise ValueError(f"This asset kind is not supported for function output: {function_output.kind}") 
         output_asset = models.OutputAsset(
+            key=str(uuid.uuid4()),
             kind=function_output.kind,
             identifier=function_output.identifier,
             asset=value,
             compute_task_key=task.key,
         )
-       
-        print("_save_output output_asset", output_asset)
         self._db.add(output_asset)
         return update_live_performances
 

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -302,7 +302,7 @@ class Worker:
                         datasample_input_refs.append(task_input)
                         datasamples.append(asset)
 
-                        # In hybrid mode, weuse DataSample assets with a path equals to `None` as it created as fake
+                        # In hybrid mode, we use DataSample assets with a path equals to `None` as it created as fake
                         # data in `_prepare_datasamples_inputs_and_paths`, but if we add these Data samples to the DB,
                         # during the execution substra will try to copy file in these folders and causes an error as
                         # these are not paths.

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -302,6 +302,10 @@ class Worker:
                         datasample_input_refs.append(task_input)
                         datasamples.append(asset)
 
+                        # In hybrid mode, weuse DataSample assets with a path equals to `None` as it created as fake
+                        # data in `_prepare_datasamples_inputs_and_paths`, but if we add these Data samples to the DB,
+                        # during the execution substra will try to copy file in these folders and causes an error as
+                        # these are not paths.
                         if asset.path:
                             addable_asset = asset
                     elif asset_type == schemas.Type.Dataset:

--- a/substra/sdk/backends/local/dal.py
+++ b/substra/sdk/backends/local/dal.py
@@ -139,7 +139,7 @@ class DataAccess:
                     performances.task_key.append(task.key)
                     performances.task_rank.append(task.rank)
                     performances.round_idx.append(task.metadata.get("round_idx"))
-                    performances.identifier.append(perf_identifier)
+                    performances.identifier.append(output.identifier)
                     performances.performance.append(output.asset)
 
         return performances

--- a/substra/sdk/backends/local/models.py
+++ b/substra/sdk/backends/local/models.py
@@ -1,0 +1,15 @@
+import uuid
+from typing import List
+
+from pydantic import Field
+
+from substra.sdk import models
+
+
+class OutputAssetDb(models.OutputAsset):
+    key: str = Field(default_factory=uuid.uuid4)
+    compute_task_key: str
+
+    @staticmethod
+    def allowed_filters() -> List[str]:
+        return super().allowed_filters() + ["compute_task_key"]

--- a/substra/sdk/backends/local/models.py
+++ b/substra/sdk/backends/local/models.py
@@ -4,12 +4,21 @@ from typing import List
 from pydantic import Field
 
 from substra.sdk import models
+from substra.sdk import schemas
 
 
-class OutputAssetDb(models.OutputAsset):
+class _TaskAssetLocal(schemas._PydanticConfig):
     key: str = Field(default_factory=uuid.uuid4)
     compute_task_key: str
 
     @staticmethod
     def allowed_filters() -> List[str]:
         return super().allowed_filters() + ["compute_task_key"]
+
+
+class OutputAssetLocal(models.OutputAsset, _TaskAssetLocal):
+    pass
+
+
+class InputAssetLocal(models.InputAsset, _TaskAssetLocal):
+    pass

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import math
-import uuid
 from copy import deepcopy
 from typing import Dict
 from typing import List
@@ -59,7 +58,25 @@ class Remote(base.BaseBackend):
         if len(outputs) != 1:
             raise ValueError("Expecting only one asset")
 
-        return models.OutputAsset(**outputs[0], key=str(uuid.uuid4()), compute_task_key=compute_task_key)
+        return models.OutputAsset(**outputs[0])
+
+    def get_output_assets(self, compute_task_key: str) -> List[models.OutputAsset]:
+        assets = self._client.list(
+            schemas.Type.Task.to_server(),
+            path=compute_task_key + "/output_assets",
+            paginated=False,
+        )
+
+        return [models.OutputAsset(**asset) for asset in assets]
+
+    def get_input_assets(self, compute_task_key: str) -> List[models.InputAsset]:
+        assets = self._client.list(
+            schemas.Type.Task.to_server(),
+            path=compute_task_key + "/input_assets",
+            paginated=False,
+        )
+
+        return [models.InputAsset(**asset) for asset in assets]
 
     def get_performances(self, key):
         """Get an compute plan performance by key."""

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -55,9 +55,9 @@ class Remote(base.BaseBackend):
         )
 
         if len(outputs) == 0:
-            raise ValueError("Expecting one asset, found none.")
+            raise exceptions.TaskAssetNotFoundError(compute_task_key=compute_task_key, identifier=identifier)
         elif len(outputs) > 1:
-            raise ValueError(f"Expecting one asset, found {outputs}")
+            raise exceptions.TaskAssetMultipleFoundError(compute_task_key=compute_task_key, identifier=identifier)
         return models.OutputAsset(**outputs[0])
 
     def list_task_output_assets(self, compute_task_key: str) -> List[models.OutputAsset]:

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -60,7 +60,7 @@ class Remote(base.BaseBackend):
 
         return models.OutputAsset(**outputs[0])
 
-    def get_output_assets(self, compute_task_key: str) -> List[models.OutputAsset]:
+    def list_task_output_assets(self, compute_task_key: str) -> List[models.OutputAsset]:
         assets = self._client.list(
             schemas.Type.Task.to_server(),
             path=compute_task_key + "/output_assets",
@@ -69,7 +69,7 @@ class Remote(base.BaseBackend):
 
         return [models.OutputAsset(**asset) for asset in assets]
 
-    def get_input_assets(self, compute_task_key: str) -> List[models.InputAsset]:
+    def list_task_input_assets(self, compute_task_key: str) -> List[models.InputAsset]:
         assets = self._client.list(
             schemas.Type.Task.to_server(),
             path=compute_task_key + "/input_assets",

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -47,6 +47,19 @@ class Remote(base.BaseBackend):
         asset = self._client.get(asset_type.to_server(), key)
         return models.SCHEMA_TO_MODEL[asset_type](**asset)
 
+    def get_output_asset(self, compute_task_key: str, identifier: str) -> models.OutputAsset:
+        outputs = self._client.list(
+            schemas.Type.Task.to_server(),
+            path=compute_task_key + "/output_assets",
+            filters={"identifier": identifier},
+            paginated=False,
+        )
+
+        if len(outputs) != 1:
+            raise ValueError("Expecting only one asset")
+
+        return models.OutputAsset(**outputs[0], compute_task_key=compute_task_key)
+
     def get_performances(self, key):
         """Get an compute plan performance by key."""
 

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -52,6 +52,7 @@ class Remote(base.BaseBackend):
             schemas.Type.Task.to_server(),
             path=compute_task_key + "/output_assets",
             filters={"identifier": [identifier]},
+            paginated=False,
         )
 
         if len(outputs) == 0:

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import math
+import uuid
 from copy import deepcopy
 from typing import Dict
 from typing import List
@@ -58,7 +59,7 @@ class Remote(base.BaseBackend):
         if len(outputs) != 1:
             raise ValueError("Expecting only one asset")
 
-        return models.OutputAsset(**outputs[0], compute_task_key=compute_task_key)
+        return models.OutputAsset(**outputs[0], key=str(uuid.uuid4()), compute_task_key=compute_task_key)
 
     def get_performances(self, key):
         """Get an compute plan performance by key."""

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -51,32 +51,28 @@ class Remote(base.BaseBackend):
         outputs = self._client.list(
             schemas.Type.Task.to_server(),
             path=compute_task_key + "/output_assets",
-            filters={"identifier": identifier},
-            paginated=False,
+            filters={"identifier": [identifier]},
         )
 
-        if len(outputs) != 1:
-            raise ValueError("Expecting only one asset")
-
+        if len(outputs) == 0:
+            raise ValueError("Expecting one asset, found none.")
+        elif len(outputs) > 1:
+            raise ValueError(f"Expecting one asset, found {outputs}")
         return models.OutputAsset(**outputs[0])
 
     def list_task_output_assets(self, compute_task_key: str) -> List[models.OutputAsset]:
-        assets = self._client.list(
+        outputs = self._client.list(
             schemas.Type.Task.to_server(),
             path=compute_task_key + "/output_assets",
-            paginated=False,
         )
-
-        return [models.OutputAsset(**asset) for asset in assets]
+        return [models.OutputAsset(**output) for output in outputs]
 
     def list_task_input_assets(self, compute_task_key: str) -> List[models.InputAsset]:
-        assets = self._client.list(
+        inputs = self._client.list(
             schemas.Type.Task.to_server(),
             path=compute_task_key + "/input_assets",
-            paginated=False,
         )
-
-        return [models.InputAsset(**asset) for asset in assets]
+        return [models.InputAsset(**i) for i in inputs]
 
     def get_performances(self, key):
         """Get an compute plan performance by key."""
@@ -106,7 +102,7 @@ class Remote(base.BaseBackend):
     def list(
         self,
         asset_type: schemas.Type,
-        filters: Dict[str, Union[List[str], str, dict]] = None,
+        filters: Dict[str, Union[List[str], dict]] = None,
         order_by: str = None,
         ascending: bool = False,
         paginated: bool = True,

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -52,7 +52,6 @@ class Remote(base.BaseBackend):
             schemas.Type.Task.to_server(),
             path=compute_task_key + "/output_assets",
             filters={"identifier": [identifier]},
-            paginated=False,
         )
 
         if len(outputs) == 0:

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -47,7 +47,7 @@ class Remote(base.BaseBackend):
         asset = self._client.get(asset_type.to_server(), key)
         return models.SCHEMA_TO_MODEL[asset_type](**asset)
 
-    def get_output_asset(self, compute_task_key: str, identifier: str) -> models.OutputAsset:
+    def get_task_output_asset(self, compute_task_key: str, identifier: str) -> models.OutputAsset:
         outputs = self._client.list(
             schemas.Type.Task.to_server(),
             path=compute_task_key + "/output_assets",

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -943,8 +943,8 @@ class Client:
         Returns:
             pathlib.Path: Path of the downloaded model
         """
-        task = self._backend.get(schemas.Type.Task, task_key)
-        model = task.outputs[identifier].value
+        task_output = self._backend.get_output_asset(task_key, identifier)
+        model = task_output.asset
         return self.download_model(model.key, folder)
 
     @logit

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -797,7 +797,7 @@ class Client:
 
 
         """
-        return self._list(schemas.Type.SummaryTask, filters, order_by, ascending)
+        return self._list(schemas.Type.Task, filters, order_by, ascending)
 
     @logit
     def list_organization(self, *args, **kwargs) -> List[models.Organization]:

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -800,6 +800,18 @@ class Client:
         return self._list(schemas.Type.Task, filters, order_by, ascending)
 
     @logit
+    def list_task_input_assets(self, key: str) -> List[models.InputAsset]:
+        """List input assets for a specific task, the returned object is described
+        in the [models.Task](sdk_models.md#Task) model"""
+        return self._backend.list_task_input_assets(key)
+
+    @logit
+    def list_task_output_assets(self, key: str) -> List[models.OutputAsset]:
+        """List output assets for a specific task, the returned object is described
+        in the [models.Task](sdk_models.md#Task) model"""
+        return self._backend.list_task_output_assets(key)
+
+    @logit
     def list_organization(self, *args, **kwargs) -> List[models.Organization]:
         """List organizations, the returned object is described
         in the [models.Organization](sdk_models.md#Organization) model"""

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -802,19 +802,19 @@ class Client:
     @logit
     def list_task_input_assets(self, key: str) -> List[models.InputAsset]:
         """List input assets for a specific task, the returned object is described
-        in the [models.Task](sdk_models.md#Task) model"""
+        in the [models.InputAsset](sdk_models.md#InputAsset) model"""
         return self._backend.list_task_input_assets(key)
 
     @logit
     def list_task_output_assets(self, key: str) -> List[models.OutputAsset]:
         """List output assets for a specific task, the returned object is described
-        in the [models.Task](sdk_models.md#Task) model"""
+        in the [models.OutputAsset](sdk_models.md#OutputAsset) model"""
         return self._backend.list_task_output_assets(key)
 
     @logit
     def get_task_output_asset(self, key: str, identifier: str) -> models.OutputAsset:
         """Get an output asset for a specific task with a defined identifier, the returned object is described
-        in the [models.Task](sdk_models.md#Task) model"""
+        in the [models.OutputAsset](sdk_models.md#OutputAsset) model"""
         return self._backend.get_task_output_asset(key, identifier)
 
     @logit

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -812,6 +812,12 @@ class Client:
         return self._backend.list_task_output_assets(key)
 
     @logit
+    def get_task_output_asset(self, key: str, identifier: str) -> models.OutputAsset:
+        """Get an output asset for a specific task with a defined identifier, the returned object is described
+        in the [models.Task](sdk_models.md#Task) model"""
+        return self._backend.get_task_output_asset(key, identifier)
+
+    @logit
     def list_organization(self, *args, **kwargs) -> List[models.Organization]:
         """List organizations, the returned object is described
         in the [models.Organization](sdk_models.md#Organization) model"""
@@ -955,7 +961,7 @@ class Client:
         Returns:
             pathlib.Path: Path of the downloaded model
         """
-        task_output = self._backend.get_output_asset(task_key, identifier)
+        task_output = self._backend.get_task_output_asset(task_key, identifier)
         model = task_output.asset
         return self.download_model(model.key, folder)
 

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -194,3 +194,34 @@ class KeyAlreadyExistsError(Exception):
     """The asset key has already been used."""
 
     pass
+
+
+class _TaskAssetError(Exception):
+    """Base eception class for task asset error"""
+
+    def __init__(self, *, compute_task_key: str, identifier: str, message: str):
+        self.compute_task_key = compute_task_key
+        self.identifier = identifier
+        self.message = message
+        super().__init__(self.message)
+
+    pass
+
+
+class TaskAssetNotFoundError(_TaskAssetError):
+    """Exception raised when no task input/output asset have not been found for specific task key and identifier"""
+
+    def __init__(self, compute_task_key: str, identifier: str):
+        message = f"No task asset found with {compute_task_key=} and {identifier=}"
+        super().__init__(compute_task_key=compute_task_key, identifier=identifier, message=message)
+
+    pass
+
+
+class TaskAssetMultipleFoundError(_TaskAssetError):
+    """Exception raised when more than one task input/output assets have been found for specific task key and
+    identifier"""
+
+    def __init__(self, compute_task_key: str, identifier: str):
+        message = f"Multiple task assets found with {compute_task_key=} and {identifier=}"
+        super().__init__(compute_task_key=compute_task_key, identifier=identifier, message=message)

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -376,13 +376,43 @@ class OrganizationInfo(schemas._PydanticConfig):
     orchestrator_version: str
 
 
+class _TaskAsset(schemas._PydanticConfig):
+    kind: str
+    asset: Union[DataSample, Dataset, OutModel]
+    identifier: str
+
+    @staticmethod
+    def allowed_filters() -> List[str]:
+        return ["compute_task_key", "identifier", "kind"]
+
+    @property
+    def key(self) -> str:
+        self.asset.key
+
+class InputAsset(_TaskAsset):
+    compute_task_key: str
+    type_: ClassVar[str] = schemas.Type.InputAsset
+
+
+class OutputAsset(_TaskAsset):
+    compute_task_key: str
+    type_: ClassVar[str] = schemas.Type.OutputAsset
+
+    @property
+    def id(self) -> str:
+        return self.asset.key
+
+
+
+
 SCHEMA_TO_MODEL = {
     schemas.Type.Task: Task,
-    schemas.Type.SummaryTask: SummaryTask,
     schemas.Type.Function: Function,
     schemas.Type.ComputePlan: ComputePlan,
     schemas.Type.DataSample: DataSample,
     schemas.Type.Dataset: Dataset,
     schemas.Type.Organization: Organization,
     schemas.Type.Model: OutModel,
+    schemas.Type.OutputAsset: OutputAsset,
+    schemas.Type.InputAsset: InputAsset,
 }

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -13,7 +13,6 @@ import pydantic
 from pydantic import AnyUrl
 from pydantic import DirectoryPath
 from pydantic import FilePath
-from pydantic import validator
 from pydantic.fields import Field
 
 from substra.sdk import schemas
@@ -397,7 +396,7 @@ class OutputAsset(_TaskAsset):
     type_: ClassVar[str] = schemas.Type.OutputAsset
 
     # Deal with remote returning the actual performance object
-    @validator("asset", pre=True)
+    @pydantic.validator("asset", pre=True)
     def convert_remote_performance(cls, value, values):
         if values.get("kind") == schemas.AssetKind.performance and isinstance(value, dict):
             return value.get("performance_value")

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -187,7 +187,7 @@ class Function(_Model):
         return ["key", "name", "owner", "permissions", "compute_plan_key", "dataset_key", "data_sample_key"]
 
     @pydantic.validator("inputs", pre=True)
-    def dict_input_to_list(cls, v):  # noqa: N805
+    def dict_input_to_list(cls, v):
         if isinstance(v, dict):
             # Transform the inputs dict to a list
             return [
@@ -203,7 +203,7 @@ class Function(_Model):
             return v
 
     @pydantic.validator("outputs", pre=True)
-    def dict_output_to_list(cls, v):  # noqa: N805
+    def dict_output_to_list(cls, v):
         if isinstance(v, dict):
             # Transform the outputs dict to a list
             return [

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -376,17 +376,23 @@ class OrganizationInfo(schemas._PydanticConfig):
     orchestrator_version: str
 
 
-class OutputAsset(schemas._PydanticConfig):
-    key: str
+class _TaskAsset(schemas._PydanticConfig):
     kind: str
     identifier: str
-    compute_task_key: str
-    asset: Union[float, OutModel]
-    type_: ClassVar[str] = schemas.Type.OutputAsset
 
     @staticmethod
     def allowed_filters() -> List[str]:
-        return ["compute_task_key", "identifier", "kind"]
+        return ["identifier", "kind"]
+
+
+class InputAsset(_TaskAsset):
+    asset: Union[DataSample, Dataset]
+    type_: ClassVar[str] = schemas.Type.InputAsset
+
+
+class OutputAsset(_TaskAsset):
+    asset: Union[float, OutModel]
+    type_: ClassVar[str] = schemas.Type.OutputAsset
 
 
 SCHEMA_TO_MODEL = {
@@ -397,5 +403,6 @@ SCHEMA_TO_MODEL = {
     schemas.Type.Dataset: Dataset,
     schemas.Type.Organization: Organization,
     schemas.Type.Model: OutModel,
+    schemas.Type.InputAsset: InputAsset,
     schemas.Type.OutputAsset: OutputAsset,
 }

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -375,32 +375,17 @@ class OrganizationInfo(schemas._PydanticConfig):
     version: str
     orchestrator_version: str
 
-
-class _TaskAsset(schemas._PydanticConfig):
+class OutputAsset(schemas._PydanticConfig):
+    key: str
     kind: str
-    asset: Union[DataSample, Dataset, OutModel]
     identifier: str
+    compute_task_key: str
+    asset: Union[float, OutModel]
+    type_: ClassVar[str] = schemas.Type.OutputAsset
 
     @staticmethod
     def allowed_filters() -> List[str]:
         return ["compute_task_key", "identifier", "kind"]
-
-    @property
-    def key(self) -> str:
-        self.asset.key
-
-class InputAsset(_TaskAsset):
-    compute_task_key: str
-    type_: ClassVar[str] = schemas.Type.InputAsset
-
-
-class OutputAsset(_TaskAsset):
-    compute_task_key: str
-    type_: ClassVar[str] = schemas.Type.OutputAsset
-
-    @property
-    def id(self) -> str:
-        return self.asset.key
 
 
 
@@ -414,5 +399,4 @@ SCHEMA_TO_MODEL = {
     schemas.Type.Organization: Organization,
     schemas.Type.Model: OutModel,
     schemas.Type.OutputAsset: OutputAsset,
-    schemas.Type.InputAsset: InputAsset,
 }

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -274,6 +274,8 @@ class Task(_Model):
     start_date: Optional[datetime]
     end_date: Optional[datetime]
     error_type: Optional[TaskErrorType] = None
+    inputs: List[InputRef]
+    outputs: Dict[str, ComputeTaskOutput]
 
     type_: ClassVar[Type] = schemas.Type.Task
 

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -260,7 +260,7 @@ class ComputeTaskOutput(schemas._PydanticConfig):
         allow_population_by_field_name = True
 
 
-class SummaryTask(_Model):
+class Task(_Model):
     key: str
     function: Function
     owner: str
@@ -289,11 +289,6 @@ class SummaryTask(_Model):
             "compute_plan_key",
             "function_key",
         ]
-
-
-class Task(SummaryTask):
-    inputs: List[InputRef]
-    outputs: Dict[str, ComputeTaskOutput]
 
 
 Task.update_forward_refs()

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -386,7 +386,7 @@ class _TaskAsset(schemas._PydanticConfig):
 
 
 class InputAsset(_TaskAsset):
-    asset: Union[DataSample, Dataset]
+    asset: Union[Dataset, DataSample, OutModel]
     type_: ClassVar[str] = schemas.Type.InputAsset
 
 

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -253,7 +253,6 @@ class ComputeTaskOutput(schemas._PydanticConfig):
     """Specification of a compute task input"""
 
     permissions: Permissions
-    value: Optional[Union[float, OutModel, List[OutModel]]]  # performance or Model or multiple model
     is_transient: bool = Field(False, alias="transient")
 
     class Config:

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -13,6 +13,7 @@ import pydantic
 from pydantic import AnyUrl
 from pydantic import DirectoryPath
 from pydantic import FilePath
+from pydantic import validator
 from pydantic.fields import Field
 
 from substra.sdk import schemas
@@ -394,6 +395,14 @@ class InputAsset(_TaskAsset):
 class OutputAsset(_TaskAsset):
     asset: Union[float, OutModel]
     type_: ClassVar[str] = schemas.Type.OutputAsset
+
+    # Deal with remote returning the actual performance object
+    @validator("asset", pre=True)
+    def convert_remote_performance(cls, value, values):
+        if values.get("kind") == schemas.AssetKind.performance and isinstance(value, dict):
+            return value.get("performance_value")
+
+        return value
 
 
 SCHEMA_TO_MODEL = {

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -375,6 +375,7 @@ class OrganizationInfo(schemas._PydanticConfig):
     version: str
     orchestrator_version: str
 
+
 class OutputAsset(schemas._PydanticConfig):
     key: str
     kind: str
@@ -386,8 +387,6 @@ class OutputAsset(schemas._PydanticConfig):
     @staticmethod
     def allowed_filters() -> List[str]:
         return ["compute_task_key", "identifier", "kind"]
-
-
 
 
 SCHEMA_TO_MODEL = {

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -146,7 +146,7 @@ class DataSampleSpec(_Spec):
         return self.paths and len(self.paths) > 0
 
     @pydantic.root_validator(pre=True)
-    def exclusive_paths(cls, values):  # noqa: N805
+    def exclusive_paths(cls, values):
         """Check that one and only one path(s) field is defined."""
         if "paths" in values and "path" in values:
             raise ValueError("'path' and 'paths' fields are exclusive.")
@@ -294,7 +294,7 @@ class FunctionInputSpec(_Spec):
     kind: AssetKind
 
     @pydantic.root_validator
-    def _check_identifiers(cls, values):  # noqa: N805
+    def _check_identifiers(cls, values):
         """Checks that the multiplicity and the optionality of a data manager is always set to False"""
         if values["kind"] == AssetKind.data_manager:
             if values["multiple"]:
@@ -328,7 +328,7 @@ class FunctionOutputSpec(_Spec):
     multiple: bool
 
     @pydantic.root_validator
-    def _check_performance(cls, values):  # noqa: N805
+    def _check_performance(cls, values):
         """Checks that the performance is always set to False"""
         if values.get("kind") == AssetKind.performance and values.get("multiple"):
             raise ValueError("Performance can't be multiple.")
@@ -353,7 +353,7 @@ class FunctionSpec(_Spec):
     type_: typing.ClassVar[Type] = Type.Function
 
     @pydantic.validator("inputs")
-    def _check_inputs(cls, v):  # noqa: N805
+    def _check_inputs(cls, v):
         inputs = v or []
         identifiers = {value.identifier for value in inputs}
         if len(identifiers) != len(inputs):
@@ -361,7 +361,7 @@ class FunctionSpec(_Spec):
         return v
 
     @pydantic.validator("outputs")
-    def _check_outputs(cls, v):  # noqa: N805
+    def _check_outputs(cls, v):
         outputs = v or []
         identifiers = {value.identifier for value in outputs}
         if len(identifiers) != len(outputs):

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -55,7 +55,6 @@ class Type(enum.Enum):
     Organization = "organization"
     Task = "task"
     OutputAsset = "output_asset"
-    InputAsset = "input_asset"
 
     def to_server(self):
         """Returns the name used to identify the asset on the backend."""

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -54,7 +54,8 @@ class Type(enum.Enum):
     ComputePlan = "compute_plan"
     Organization = "organization"
     Task = "task"
-    SummaryTask = "summary_task"
+    OutputAsset = "output_asset"
+    InputAsset = "input_asset"
 
     def to_server(self):
         """Returns the name used to identify the asset on the backend."""

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -54,6 +54,7 @@ class Type(enum.Enum):
     ComputePlan = "compute_plan"
     Organization = "organization"
     Task = "task"
+    InputAsset = "input_asset"
     OutputAsset = "output_asset"
 
     def to_server(self):

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -62,6 +62,13 @@ class Type(enum.Enum):
         name = self.value
         return _SERVER_NAMES.get(name, name)
 
+    def to_asset_kind(self):
+        """Returns the name used to identify the asset on the backend."""
+        if self.value == self.Dataset.value:
+            return AssetKind.data_manager
+        else:
+            return AssetKind[self.value]
+
     def __str__(self):
         return self.name
 

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -559,10 +559,8 @@ TESTTASK = {
     },
 }
 
-TASK_LIST = [
-    {key: value for key, value in task.items() if key not in {"inputs", "outputs"}}
-    for task in [PREDICTTASK, AGGREGATETASK, COMPOSITE_TRAINTASK, TRAINTASK, TESTTASK]
-]
+TASK_LIST = [PREDICTTASK, AGGREGATETASK, COMPOSITE_TRAINTASK, TRAINTASK, TESTTASK]
+
 
 COMPUTE_PLAN = {
     "key": "e983a185-5368-bd0a-0190-183af9a8e560",

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -191,26 +191,26 @@ TRAINTASK = {
     },
 }
 
-TRAINTASK_MODEL = [
-    {
-        "asset": {
-            "key": "6f0ee20a328044fb89e70ee5d219fa0c",
-            "compute_task_key": "30c283be-d385-424e-94a6-4d8538275260",
-            "address": {
-                "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
-                "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/5f0ee20a328044fb89e70ee5d219fa0b/address/",  # noqa: E501
-            },
-            "permissions": {
-                "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-            },
-            "owner": "MyOrg1MSP",
-            "creation_date": "2021-08-24T13:36:07.393646367Z",
+TRAINTASK_MODEL = {
+    "asset": {
+        "key": "6f0ee20a328044fb89e70ee5d219fa0c",
+        "compute_task_key": "30c283be-d385-424e-94a6-4d8538275260",
+        "address": {
+            "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
+            "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/5f0ee20a328044fb89e70ee5d219fa0b/address/",  # noqa: E501
         },
-        "identifier": "model",
-        "kind": "ASSET_MODEL",
-    }
-]
+        "permissions": {
+            "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+            "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+        },
+        "owner": "MyOrg1MSP",
+        "creation_date": "2021-08-24T13:36:07.393646367Z",
+    },
+    "identifier": "model",
+    "kind": "ASSET_MODEL",
+}
+
+TRAINTASK_MODEL_RESPONSE = {"count": 1, "previous": None, "next": None, "results": [TRAINTASK_MODEL]}
 
 AGGREGATETASK = {
     "key": "06207faf-1785-4fa9-4220-99a50dcfe064",
@@ -257,26 +257,26 @@ AGGREGATETASK = {
     },
 }
 
-AGGREGATETASK_MODEL = [
-    {
-        "asset": {
-            "key": "5f0ee20a328044fb89e70ee5d219fa0b",
-            "compute_task_key": "06207faf-1785-4fa9-4220-99a50dcfe064",
-            "address": {
-                "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
-                "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/5f0ee20a328044fb89e70ee5d219fa0b/address/",  # noqa: E501
-            },
-            "permissions": {
-                "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-            },
-            "owner": "MyOrg1MSP",
-            "creation_date": "2021-08-24T13:36:07.393646367Z",
+AGGREGATETASK_MODEL = {
+    "asset": {
+        "key": "5f0ee20a328044fb89e70ee5d219fa0b",
+        "compute_task_key": "06207faf-1785-4fa9-4220-99a50dcfe064",
+        "address": {
+            "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
+            "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/5f0ee20a328044fb89e70ee5d219fa0b/address/",  # noqa: E501
         },
-        "identifier": "model",
-        "kind": "ASSET_MODEL",
-    }
-]
+        "permissions": {
+            "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+            "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+        },
+        "owner": "MyOrg1MSP",
+        "creation_date": "2021-08-24T13:36:07.393646367Z",
+    },
+    "identifier": "model",
+    "kind": "ASSET_MODEL",
+}
+
+AGGREGATETASK_MODEL_RESPONSE = {"count": 1, "previous": None, "next": None, "results": [AGGREGATETASK_MODEL]}
 
 COMPOSITE_TRAINTASK = {
     "key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
@@ -341,46 +341,55 @@ COMPOSITE_TRAINTASK = {
     },
 }
 
-COMPOSITE_TRAINTASK_SHARED = [
-    {
-        "asset": {
-            "key": "dc9d114d1ed54936b57dd7fef1c0cbf4",
-            "compute_task_key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
-            "address": {
-                "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
-                "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/ac4a1a82ced4419b83f4bba78c024b94/address/",  # noqa: E501
-            },
-            "permissions": {
-                "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-            },
-            "owner": "MyOrg1MSP",
-            "creation_date": "2021-08-24T13:36:07.393646367Z",
+COMPOSITE_TRAINTASK_SHARED = {
+    "asset": {
+        "key": "dc9d114d1ed54936b57dd7fef1c0cbf4",
+        "compute_task_key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
+        "address": {
+            "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
+            "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/ac4a1a82ced4419b83f4bba78c024b94/address/",  # noqa: E501
         },
-        "identifier": "shared",
-        "kind": "ASSET_MODEL",
-    }
-]
-COMPOSITE_TRAINTASK_LOCAL = [
-    {
-        "asset": {
-            "key": "dc9d114d1ed54936b57dd7fef1c0cbf4",
-            "compute_task_key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
-            "address": {
-                "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
-                "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/ac4a1a82ced4419b83f4bba78c024b94/address/",  # noqa: E501
-            },
-            "permissions": {
-                "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-            },
-            "owner": "MyOrg1MSP",
-            "creation_date": "2021-08-24T13:36:07.393646367Z",
+        "permissions": {
+            "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+            "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
         },
-        "identifier": "local",
-        "kind": "ASSET_MODEL",
-    }
-]
+        "owner": "MyOrg1MSP",
+        "creation_date": "2021-08-24T13:36:07.393646367Z",
+    },
+    "identifier": "shared",
+    "kind": "ASSET_MODEL",
+}
+
+
+COMPOSITE_TRAINTASK_SHARED_RESPONSE = {"count": 1, "previous": None, "next": None, "results": [AGGREGATETASK_MODEL]}
+
+COMPOSITE_TRAINTASK_LOCAL = {
+    "asset": {
+        "key": "dc9d114d1ed54936b57dd7fef1c0cbf4",
+        "compute_task_key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
+        "address": {
+            "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
+            "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/ac4a1a82ced4419b83f4bba78c024b94/address/",  # noqa: E501
+        },
+        "permissions": {
+            "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+            "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+        },
+        "owner": "MyOrg1MSP",
+        "creation_date": "2021-08-24T13:36:07.393646367Z",
+    },
+    "identifier": "local",
+    "kind": "ASSET_MODEL",
+}
+
+
+COMPOSITE_TRAINTASK_LOCAL_RESPONSE = {
+    "count": 1,
+    "previous": None,
+    "next": None,
+    "results": [COMPOSITE_TRAINTASK_LOCAL],
+}
+
 COMPOSITE_TRAINTASK_DOING = {
     "key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
     "function": {

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -48,7 +48,7 @@ DATASET = {
 }
 
 DATA_SAMPLE = {
-    "key": "d7dc4a5b-e81f-4f3f-b94c-5e2bbaca15cd",
+    "key": "7096db67-c175-4b45-9fb3-ad785eebb347",
     "owner": "MyOrg1MSP",
     "data_manager_keys": ["d7dc4a5b-e81f-4f3f-b94c-5e2bbaca15cd"],
     "creation_date": "2021-08-24T13:36:07.428974249Z",
@@ -174,7 +174,7 @@ TRAINTASK = {
     "start_date": "2021-10-12T09:28:06.947765800Z",
     "end_date": "2021-10-12T09:30:04.705947400Z",
     "inputs": [
-        {"identifier": "opener", "asset_key": "a67b9387-fd80-429a-bc2f-034fac430b0f"},
+        {"identifier": "opener", "asset_key": "d7dc4a5b-e81f-4f3f-b94c-5e2bbaca15cd"},
         {"identifier": "datasamples", "asset_key": "3180e12c-a821-434a-ad8a-a341076c7f98"},
         {"identifier": "datasamples", "asset_key": "21bb59ca-abd4-4154-b04a-44a92556a078"},
         {"identifier": "datasamples", "asset_key": "67512646-2464-4521-84de-419b1b307d30"},
@@ -481,7 +481,7 @@ PREDICTTASK = {
     "start_date": "2021-10-12T09:28:06.947765800Z",
     "end_date": "2021-10-12T09:30:04.705947400Z",
     "inputs": [
-        {"identifier": "opener", "asset_key": "a67b9387-fd80-429a-bc2f-034fac430b0f"},
+        {"identifier": "opener", "asset_key": "d7dc4a5b-e81f-4f3f-b94c-5e2bbaca15cd"},
         {"identifier": "datasamples", "asset_key": "3180e12c-a821-434a-ad8a-a341076c7f98"},
         {"identifier": "datasamples", "asset_key": "21bb59ca-abd4-4154-b04a-44a92556a078"},
         {
@@ -539,7 +539,7 @@ TESTTASK = {
     "start_date": "2021-10-12T09:28:06.947765800Z",
     "end_date": "2021-10-12T09:30:04.705947400Z",
     "inputs": [
-        {"identifier": "opener", "asset_key": "a67b9387-fd80-429a-bc2f-034fac430b0f"},
+        {"identifier": "opener", "asset_key": "d7dc4a5b-e81f-4f3f-b94c-5e2bbaca15cd"},
         {"identifier": "datasamples", "asset_key": "3180e12c-a821-434a-ad8a-a341076c7f98"},
         {"identifier": "datasamples", "asset_key": "21bb59ca-abd4-4154-b04a-44a92556a078"},
         {
@@ -593,7 +593,7 @@ COMPUTE_PLAN_PERF = {
         {
             "compute_task": {
                 "key": "afa9c7b1-21b5-4e58-a098-79de4ecede35",
-                "data_manager_key": "a67b9387-fd80-429a-bc2f-034fac430b0f",
+                "data_manager_key": "d7dc4a5b-e81f-4f3f-b94c-5e2bbaca15cd",
                 "function_key": "17f98afc-2b82-4ce9-b232-1a471633d020",
                 "rank": 1,
                 "epoch": None,
@@ -610,7 +610,7 @@ COMPUTE_PLAN_PERF = {
         {
             "compute_task": {
                 "key": "afa9c7b1-21b5-4e58-a098-79de4ecede35",
-                "data_manager_key": "a67b9387-fd80-429a-bc2f-034fac430b0f",
+                "data_manager_key": "d7dc4a5b-e81f-4f3f-b94c-5e2bbaca15cd",
                 "function_key": "17f98afc-2b82-4ce9-b232-1a471633d020",
                 "rank": 2,
                 "epoch": None,
@@ -627,7 +627,7 @@ COMPUTE_PLAN_PERF = {
         {
             "compute_task": {
                 "key": "afa9c7b1-21b5-4e58-a098-79de4ecede35",
-                "data_manager_key": "a67b9387-fd80-429a-bc2f-034fac430b0f",
+                "data_manager_key": "d7dc4a5b-e81f-4f3f-b94c-5e2bbaca15cd",
                 "function_key": "17f98afc-2b82-4ce9-b232-1a471633d020",
                 "rank": 3,
                 "epoch": None,

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -187,23 +187,30 @@ TRAINTASK = {
                 "download": {"public": True, "authorized_ids": ["MyOrg1MSP"]},
             },
             "transient": False,
-            "value": {
-                "key": "6f0ee20a328044fb89e70ee5d219fa0c",
-                "compute_task_key": "30c283be-d385-424e-94a6-4d8538275260",
-                "address": {
-                    "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
-                    "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/5f0ee20a328044fb89e70ee5d219fa0b/address/",  # noqa: E501
-                },
-                "permissions": {
-                    "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                    "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                },
-                "owner": "MyOrg1MSP",
-                "creation_date": "2021-08-24T13:36:07.393646367Z",
-            },
         },
     },
 }
+
+TRAINTASK_MODEL = [
+    {
+        "asset": {
+            "key": "6f0ee20a328044fb89e70ee5d219fa0c",
+            "compute_task_key": "30c283be-d385-424e-94a6-4d8538275260",
+            "address": {
+                "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
+                "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/5f0ee20a328044fb89e70ee5d219fa0b/address/",  # noqa: E501
+            },
+            "permissions": {
+                "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+                "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+            },
+            "owner": "MyOrg1MSP",
+            "creation_date": "2021-08-24T13:36:07.393646367Z",
+        },
+        "identifier": "model",
+        "kind": "ASSET_MODEL",
+    }
+]
 
 AGGREGATETASK = {
     "key": "06207faf-1785-4fa9-4220-99a50dcfe064",
@@ -246,23 +253,30 @@ AGGREGATETASK = {
                 "download": {"public": True, "authorized_ids": ["MyOrg1MSP"]},
             },
             "transient": False,
-            "value": {
-                "key": "5f0ee20a328044fb89e70ee5d219fa0b",
-                "compute_task_key": "06207faf-1785-4fa9-4220-99a50dcfe064",
-                "address": {
-                    "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
-                    "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/5f0ee20a328044fb89e70ee5d219fa0b/address/",  # noqa: E501
-                },
-                "permissions": {
-                    "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                    "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                },
-                "owner": "MyOrg1MSP",
-                "creation_date": "2021-08-24T13:36:07.393646367Z",
-            },
         },
     },
 }
+
+AGGREGATETASK_MODEL = [
+    {
+        "asset": {
+            "key": "5f0ee20a328044fb89e70ee5d219fa0b",
+            "compute_task_key": "06207faf-1785-4fa9-4220-99a50dcfe064",
+            "address": {
+                "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
+                "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/5f0ee20a328044fb89e70ee5d219fa0b/address/",  # noqa: E501
+            },
+            "permissions": {
+                "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+                "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+            },
+            "owner": "MyOrg1MSP",
+            "creation_date": "2021-08-24T13:36:07.393646367Z",
+        },
+        "identifier": "model",
+        "kind": "ASSET_MODEL",
+    }
+]
 
 COMPOSITE_TRAINTASK = {
     "key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
@@ -316,20 +330,6 @@ COMPOSITE_TRAINTASK = {
                 "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
             },
             "transient": False,
-            "value": {
-                "key": "dc9d114d1ed54936b57dd7fef1c0cbf4",
-                "compute_task_key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
-                "address": {
-                    "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
-                    "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/ac4a1a82ced4419b83f4bba78c024b94/address/",  # noqa: E501
-                },
-                "permissions": {
-                    "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                    "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                },
-                "owner": "MyOrg1MSP",
-                "creation_date": "2021-08-24T13:36:07.393646367Z",
-            },
         },
         "local": {
             "permissions": {
@@ -337,24 +337,50 @@ COMPOSITE_TRAINTASK = {
                 "download": {"public": False, "authorized_ids": ["MyOrg2MSP"]},
             },
             "transient": False,
-            "value": {
-                "key": "ac4a1a82ced4419b83f4bba78c024b94",
-                "compute_task_key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
-                "address": {
-                    "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
-                    "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/ac4a1a82ced4419b83f4bba78c024b94/address/",  # noqa: E501
-                },
-                "permissions": {
-                    "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                    "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
-                },
-                "owner": "MyOrg1MSP",
-                "creation_date": "2021-08-24T13:36:07.393646367Z",
-            },
         },
     },
 }
 
+COMPOSITE_TRAINTASK_SHARED = [
+    {
+        "asset": {
+            "key": "dc9d114d1ed54936b57dd7fef1c0cbf4",
+            "compute_task_key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
+            "address": {
+                "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
+                "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/ac4a1a82ced4419b83f4bba78c024b94/address/",  # noqa: E501
+            },
+            "permissions": {
+                "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+                "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+            },
+            "owner": "MyOrg1MSP",
+            "creation_date": "2021-08-24T13:36:07.393646367Z",
+        },
+        "identifier": "shared",
+        "kind": "ASSET_MODEL",
+    }
+]
+COMPOSITE_TRAINTASK_LOCAL = [
+    {
+        "asset": {
+            "key": "dc9d114d1ed54936b57dd7fef1c0cbf4",
+            "compute_task_key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
+            "address": {
+                "checksum": "40483cd8b99ea7fbd3b73020997ea07547771993a6a3fa56fa2a8e9d7860529e",
+                "storage_address": "http://backend-org-1-substra-backend-server.org-1:8000/model/ac4a1a82ced4419b83f4bba78c024b94/address/",  # noqa: E501
+            },
+            "permissions": {
+                "process": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+                "download": {"public": False, "authorized_ids": ["MyOrg1MSP", "MyOrg2MSP"]},
+            },
+            "owner": "MyOrg1MSP",
+            "creation_date": "2021-08-24T13:36:07.393646367Z",
+        },
+        "identifier": "local",
+        "kind": "ASSET_MODEL",
+    }
+]
 COMPOSITE_TRAINTASK_DOING = {
     "key": "aa09180a-fec6-46a5-a1a7-58c971b39217",
     "function": {

--- a/tests/sdk/local/test_debug.py
+++ b/tests/sdk/local/test_debug.py
@@ -168,65 +168,66 @@ class TestsDebug:
         metric_key = client.add_function(metric_query)
 
         # test traintask extra field
-        inputs = FLTaskInputGenerator.task(opener_key=dataset_key, data_sample_keys=[data_sample_key])
+
         traintask_key = client.add_task(
             substra.sdk.schemas.TaskSpec(
                 function_key=function_key,
-                worker=client.organization_info().organization_id,
-                inputs=inputs,
+                inputs=FLTaskInputGenerator.task(opener_key=dataset_key, data_sample_keys=[data_sample_key]),
                 outputs=FLTaskOutputGenerator.traintask(),
+                worker=client.organization_info().organization_id,
             )
         )
-        client.get_task(traintask_key)
-        dataset_ref = [x for x in inputs if x.identifier == substra.sdk.schemas.StaticInputIdentifier.opener]
+
+        traintask = client.get_task(traintask_key)
+        dataset_ref = [x for x in traintask.inputs if x.identifier == substra.sdk.schemas.StaticInputIdentifier.opener]
         assert len(dataset_ref) == 1
         assert dataset_ref[0].asset_key == dataset_key
-        assert len(inputs) == 2  # data sample + opener
+        assert len(traintask.inputs) == 2  # data sample + opener
 
         # test predicttask extra fields
-        input_specs = FLTaskInputGenerator.task(
-            opener_key=dataset_key, data_sample_keys=[data_sample_key]
-        ) + FLTaskInputGenerator.train_to_predict(traintask_key)
         predicttask_key = client.add_task(
             substra.sdk.schemas.TaskSpec(
                 function_key=predict_function_key,
-                inputs=input_specs,
+                inputs=FLTaskInputGenerator.task(opener_key=dataset_key, data_sample_keys=[data_sample_key])
+                + FLTaskInputGenerator.train_to_predict(traintask_key),
                 outputs=FLTaskOutputGenerator.predicttask(),
                 worker=client.organization_info().organization_id,
             )
         )
 
-        client.get_task(predicttask_key)
-        dataset_ref = [x for x in input_specs if x.identifier == substra.sdk.schemas.StaticInputIdentifier.opener]
+        predicttask = client.get_task(predicttask_key)
+        dataset_ref = [
+            x for x in predicttask.inputs if x.identifier == substra.sdk.schemas.StaticInputIdentifier.opener
+        ]
         assert len(dataset_ref) == 1
         assert dataset_ref[0].asset_key == dataset_key
 
-        assert len(input_specs) == 3  # data sample + opener + input task
+        assert len(predicttask.inputs) == 3  # data sample + opener + input task
 
-        model_ref = [x for x in input_specs if x.identifier == InputIdentifiers.model]
+        model_ref = [x for x in predicttask.inputs if x.identifier == InputIdentifiers.model]
         assert len(model_ref) == 1
         assert model_ref[0].parent_task_key == traintask_key
 
         # test testtask extra fields
-        input_specs = FLTaskInputGenerator.task(
-            opener_key=dataset_key, data_sample_keys=[data_sample_key]
-        ) + FLTaskInputGenerator.predict_to_test(predicttask_key)
         testtask_key = client.add_task(
             substra.sdk.schemas.TaskSpec(
                 function_key=metric_key,
-                inputs=input_specs,
+                inputs=FLTaskInputGenerator.task(opener_key=dataset_key, data_sample_keys=[data_sample_key])
+                + FLTaskInputGenerator.predict_to_test(predicttask_key),
                 outputs=FLTaskOutputGenerator.testtask(),
                 worker=client.organization_info().organization_id,
             )
         )
         testtask = client.get_task(testtask_key)
 
-        dataset_ref = [x for x in input_specs if x.identifier == substra.sdk.schemas.StaticInputIdentifier.opener]
+        dataset_ref = [
+            x for x in predicttask.inputs if x.identifier == substra.sdk.schemas.StaticInputIdentifier.opener
+        ]
         assert len(dataset_ref) == 1
         assert dataset_ref[0].asset_key == dataset_key
-        assert len(input_specs) == 3  # data sample + opener + input task
+        assert len(predicttask.inputs) == 3  # data sample + opener + input task
 
-        model_ref = [x for x in input_specs if x.identifier == InputIdentifiers.predictions]
+        model_ref = [x for x in testtask.inputs if x.identifier == InputIdentifiers.predictions]
         assert len(model_ref) == 1
         assert model_ref[0].parent_task_key == predicttask_key
 
@@ -234,21 +235,23 @@ class TestsDebug:
         assert testtask.function.key == metric_key
 
         # test composite extra field
-        input_specs = FLTaskInputGenerator.task(opener_key=dataset_key, data_sample_keys=[data_sample_key])
+
         composite_traintask_key = client.add_task(
             substra.sdk.schemas.TaskSpec(
                 function_key=composite_function_key,
-                inputs=input_specs,
+                inputs=FLTaskInputGenerator.task(opener_key=dataset_key, data_sample_keys=[data_sample_key]),
                 outputs=FLTaskOutputGenerator.composite_traintask(),
                 worker=client.organization_info().organization_id,
             )
         )
 
-        client.get_task(composite_traintask_key)
-        dataset_ref = [x for x in input_specs if x.identifier == substra.sdk.schemas.StaticInputIdentifier.opener]
+        composite_traintask = client.get_task(composite_traintask_key)
+        dataset_ref = [
+            x for x in composite_traintask.inputs if x.identifier == substra.sdk.schemas.StaticInputIdentifier.opener
+        ]
         assert len(dataset_ref) == 1
         assert dataset_ref[0].asset_key == dataset_key
-        assert len(input_specs) == 2  # data sample + opener
+        assert len(composite_traintask.inputs) == 2  # data sample + opener
 
     def test_add_two_compute_plan_with_same_cp_key(self, clients):
         client = clients[0]

--- a/tests/sdk/test_download.py
+++ b/tests/sdk/test_download.py
@@ -81,7 +81,7 @@ def test_download_content_not_found(asset_type, tmp_path, client, mocker):
 )
 @patch.object(Client, "download_model")
 def test_download_model_from_task(fake_download_model, tmp_path, client, asset_type, identifier, mocker):
-    item = getattr(datastore, asset_type)
+    item = getattr(datastore, f"{asset_type}_{identifier.upper()}")
     responses = [
         mock_response(item),  # metadata
         mock_response("foo"),  # data

--- a/tests/sdk/test_download.py
+++ b/tests/sdk/test_download.py
@@ -81,7 +81,7 @@ def test_download_content_not_found(asset_type, tmp_path, client, mocker):
 )
 @patch.object(Client, "download_model")
 def test_download_model_from_task(fake_download_model, tmp_path, client, asset_type, identifier, mocker):
-    item = getattr(datastore, f"{asset_type}_{identifier.upper()}")
+    item = getattr(datastore, f"{asset_type}_{identifier.upper()}_RESPONSE")
     responses = [
         mock_response(item),  # metadata
         mock_response("foo"),  # data

--- a/tests/sdk/test_list.py
+++ b/tests/sdk/test_list.py
@@ -50,7 +50,7 @@ def test_list_task(asset_type, client, mocker):
 
     response = client.list_task()
 
-    assert response == [models.SummaryTask(**item)]
+    assert response == [models.Task(**item)]
     m.assert_called()
 
 
@@ -94,7 +94,7 @@ def test_list_task_with_filters(filters, client, mocker):
 
     response = client.list_task(filters)
 
-    assert response == [models.SummaryTask(**item) for item in items]
+    assert response == [models.Task(**item) for item in items]
     m.assert_called()
 
 
@@ -132,7 +132,7 @@ def test_list_task_with_ordering(client, mocker):
     order_by = "start_date"
     response = client.list_task(order_by=order_by)
 
-    assert response == [models.SummaryTask(**item) for item in items]
+    assert response == [models.Task(**item) for item in items]
     m.assert_called()
 
 


### PR DESCRIPTION
## Related issue

- https://github.com/Substra/substra-backend/pull/509
- https://github.com/Substra/substra-tests/pull/256
- https://github.com/Substra/substrafl/pull/129

## Summary

Modify substra to not rely on `asset` / `value` in Input assets and output assets.

Fixes FL-652

## Test

Ci in `substra` companion PR

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
