### PR TITLE
feat: add `_wait`, `wait_task` and `wait_compute_plan` on `substra.Client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `wait_task` and `wait_compute_plan` to block execution until execution is over ([#368](https://github.com/Substra/substra/pull/368))
+
 ### Changed
 
 - Remove `model` and `models` for input and output identifiers in tests. Replace by `shared` instead. ([#367](https://github.com/Substra/substra/pull/367))

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -4,11 +4,13 @@ import logging
 import os
 import pathlib
 import time
+from collections.abc import Callable
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Literal
 from typing import Optional
+from typing import Sequence
 from typing import Union
 
 import yaml
@@ -80,7 +82,7 @@ def _get_config_value(
     code_values: Dict[str, Any],
     client_name: Optional[str],
     client_config_dict: Dict[str, str],
-    mapping: Dict[str, callable],
+    mapping: Dict[str, Callable],
 ) -> SettingValue:
     """
     For a given attribute, return the value to be used in the Client configuration.
@@ -949,3 +951,111 @@ class Client:
     def cancel_compute_plan(self, key: str) -> None:
         """Cancel execution of compute plan. Nothing is returned by this method"""
         self._backend.cancel_compute_plan(key)
+
+    @logit
+    def wait_compute_plan(
+        self, key: str, *, timeout: Optional[float] = None, polling_period: float = 2.0, raises: bool = True
+    ) -> models.ComputePlan:
+        """Block the execution until the compute plan finishes.
+
+        It is considered finished when the status is done, failed or cancelled.
+        If a timeout is defined, will raises a `FutureTimeoutError` once it reached it.
+
+        Args:
+            key (str): the key of the compute plan to wait
+            timeout (Optional[float]): maximum time to wait. If set to None, will hang until completion.
+            polling_period (float): time to wait between to checks, in seconds. Default to 2.0.
+            raises (bool): wether or not to raises exception if the execution fails. Default to True.
+
+        Returns:
+            models.ComputePlan: the compute plan after completion
+        """
+        asset_getter = self.get_compute_plan
+        status_failed = models.ComputePlanStatus.failed.value
+        status_canceled = models.ComputePlanStatus.canceled.value
+        statuses_stopped = (
+            models.ComputePlanStatus.done.value,
+            models.ComputePlanStatus.failed.value,
+            models.ComputePlanStatus.canceled.value,
+        )
+
+        return self._wait(
+            key=key,
+            asset_getter=asset_getter,
+            polling_period=polling_period,
+            raises=raises,
+            status_canceled=status_canceled,
+            status_failed=status_failed,
+            statuses_stopped=statuses_stopped,
+            timeout=timeout,
+        )
+
+    @logit
+    def wait_task(
+        self, key: str, *, timeout: Optional[float] = None, polling_period: float = 2.0, raises: bool = True
+    ) -> models.Task:
+        """Block the execution until the task finishes.
+
+        It is considered finished when the status is done, failed or cancelled.
+        If a timeout is defined, will raises a `FutureTimeoutError` once it reached it.
+
+        Args:
+            key (str): the key of the task to wait
+            timeout (Optional[float]): maximum time to wait. If set to None, will hang until completion.
+            polling_period (float): time to wait between to checks, in seconds. Default to 2.0.
+            raises (bool): wether or not to raises exception if the execution fails. Default to True.
+
+        Returns:
+            models.Task: the task after completion
+        """
+        asset_getter = self.get_task
+        status_canceled = models.Status.canceled.value
+        status_failed = models.Status.failed.value
+        statuses_stopped = (models.Status.done.value, models.Status.canceled.value)
+        return self._wait(
+            key=key,
+            asset_getter=asset_getter,
+            polling_period=polling_period,
+            raises=raises,
+            status_canceled=status_canceled,
+            status_failed=status_failed,
+            statuses_stopped=statuses_stopped,
+            timeout=timeout,
+        )
+
+    def _wait(
+        self,
+        *,
+        key: str,
+        asset_getter,
+        polling_period: float,
+        raises: bool,
+        status_failed: str,
+        status_canceled: str,
+        statuses_stopped: Sequence[str],
+        timeout: Optional[float] = None,
+    ):
+        tstart = time.time()
+        while True:
+            asset = asset_getter(key)
+
+            if asset.status in statuses_stopped:
+                break
+
+            if asset.status == models.Status.failed.value and asset.error_type is not None:
+                # when dealing with a failed task, wait for the error_type field of the task to be set
+                # i.e. wait for the registration of the failure report
+                break
+
+            if timeout and time.time() - tstart > timeout:
+                raise exceptions.FutureTimeoutError(f"Future timeout on {asset}")
+
+            time.sleep(polling_period)
+
+        if raises and asset.status == status_failed:
+            raise exceptions.FutureFailureError(f"Future execution failed on {asset}")
+
+        if raises and asset.status == status_canceled:
+            raise exceptions.FutureFailureError(f"Future execution canceled on {asset}")
+
+        return asset

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -954,7 +954,7 @@ class Client:
 
     @logit
     def wait_compute_plan(
-        self, key: str, *, timeout: Optional[float] = None, polling_period: float = 2.0, raises: bool = True
+        self, key: str, *, timeout: Optional[float] = None, polling_period: float = 2.0, raise_on_failure: bool = True
     ) -> models.ComputePlan:
         """Wait for the execution of the given compute plan to finish.
 
@@ -964,7 +964,7 @@ class Client:
             key (str): the key of the compute plan to wait for
             timeout (float, optional): maximum time to wait, in seconds. If set to None, will hang until completion.
             polling_period (float): time to wait between two checks, in seconds. Defaults to 2.0.
-            raises (bool): whether to raise an exception if the execution fails. Defaults to True.
+            raise_on_failure (bool): whether to raise an exception if the execution fails. Defaults to True.
 
         Returns:
             models.ComputePlan: the compute plan after completion
@@ -987,7 +987,7 @@ class Client:
             key=key,
             asset_getter=asset_getter,
             polling_period=polling_period,
-            raises=raises,
+            raise_on_failure=raise_on_failure,
             status_canceled=status_canceled,
             status_failed=status_failed,
             statuses_stopped=statuses_stopped,
@@ -996,7 +996,7 @@ class Client:
 
     @logit
     def wait_task(
-        self, key: str, *, timeout: Optional[float] = None, polling_period: float = 2.0, raises: bool = True
+        self, key: str, *, timeout: Optional[float] = None, polling_period: float = 2.0, raise_on_failure: bool = True
     ) -> models.Task:
         """Wait for the execution of the given task to finish.
 
@@ -1006,7 +1006,7 @@ class Client:
             key (str): the key of the task to wait for.
             timeout (float, optional): maximum time to wait, in seconds. If set to None, will hang until completion.
             polling_period (float): time to wait between two checks, in seconds. Defaults to 2.0.
-            raises (bool): whether to raise an exception if the execution fails. Defaults to True.
+            raise_on_failure (bool): whether to raise an exception if the execution fails. Defaults to True.
 
         Returns:
             models.Task: the task after completion
@@ -1024,7 +1024,7 @@ class Client:
             key=key,
             asset_getter=asset_getter,
             polling_period=polling_period,
-            raises=raises,
+            raise_on_failure=raise_on_failure,
             status_canceled=status_canceled,
             status_failed=status_failed,
             statuses_stopped=statuses_stopped,
@@ -1037,7 +1037,7 @@ class Client:
         key: str,
         asset_getter,
         polling_period: float,
-        raises: bool,
+        raise_on_failure: bool,
         status_failed: str,
         status_canceled: str,
         statuses_stopped: Sequence[str],
@@ -1060,10 +1060,10 @@ class Client:
 
             time.sleep(polling_period)
 
-        if raises and asset.status == status_failed:
+        if raise_on_failure and asset.status == status_failed:
             raise exceptions.FutureFailureError(f"Future execution failed on {asset}")
 
-        if raises and asset.status == status_canceled:
+        if raise_on_failure and asset.status == status_canceled:
             raise exceptions.FutureFailureError(f"Future execution canceled on {asset}")
 
         return asset

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -1001,7 +1001,6 @@ class Client:
         """Wait for the execution of the given task to finish.
 
         It is considered finished when the status is done, failed or cancelled.
-        If a timeout is defined, will raises a `FutureTimeoutError` once it reached it.
 
         Args:
             key (str): the key of the task to wait for.

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -956,19 +956,23 @@ class Client:
     def wait_compute_plan(
         self, key: str, *, timeout: Optional[float] = None, polling_period: float = 2.0, raises: bool = True
     ) -> models.ComputePlan:
-        """Block the execution until the compute plan finishes.
+        """Wait for the execution of the given compute plan to finish.
 
         It is considered finished when the status is done, failed or cancelled.
-        If a timeout is defined, will raises a `FutureTimeoutError` once it reached it.
 
         Args:
-            key (str): the key of the compute plan to wait
-            timeout (Optional[float]): maximum time to wait. If set to None, will hang until completion.
-            polling_period (float): time to wait between to checks, in seconds. Default to 2.0.
-            raises (bool): wether or not to raises exception if the execution fails. Default to True.
+            key (str): the key of the compute plan to wait for
+            timeout (float, optional): maximum time to wait, in seconds. If set to None, will hang until completion.
+            polling_period (float): time to wait between two checks, in seconds. Defaults to 2.0.
+            raises (bool): whether to raise an exception if the execution fails. Defaults to True.
 
         Returns:
             models.ComputePlan: the compute plan after completion
+
+        Raises:
+            exceptions.FutureFailureError: The compute plan failed or have been cancelled.
+            exceptions.FutureTimeoutError: The compute plan took more than the duration set in the timeout to complete.
+                Not raised when `timeout == None`
         """
         asset_getter = self.get_compute_plan
         status_failed = models.ComputePlanStatus.failed.value
@@ -994,19 +998,24 @@ class Client:
     def wait_task(
         self, key: str, *, timeout: Optional[float] = None, polling_period: float = 2.0, raises: bool = True
     ) -> models.Task:
-        """Block the execution until the task finishes.
+        """Wait for the execution of the given task to finish.
 
         It is considered finished when the status is done, failed or cancelled.
         If a timeout is defined, will raises a `FutureTimeoutError` once it reached it.
 
         Args:
-            key (str): the key of the task to wait
-            timeout (Optional[float]): maximum time to wait. If set to None, will hang until completion.
-            polling_period (float): time to wait between to checks, in seconds. Default to 2.0.
-            raises (bool): wether or not to raises exception if the execution fails. Default to True.
+            key (str): the key of the task to wait for.
+            timeout (float, optional): maximum time to wait, in seconds. If set to None, will hang until completion.
+            polling_period (float): time to wait between two checks, in seconds. Defaults to 2.0.
+            raises (bool): whether to raise an exception if the execution fails. Defaults to True.
 
         Returns:
             models.Task: the task after completion
+
+         Raises:
+            exceptions.FutureFailureError: The task failed or have been cancelled.
+            exceptions.FutureTimeoutError: The task took more than the duration set in the timeout to complete.
+                Not raised when `timeout == None`
         """
         asset_getter = self.get_task
         status_canceled = models.Status.canceled.value

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -225,3 +225,15 @@ class TaskAssetMultipleFoundError(_TaskAssetError):
     def __init__(self, compute_task_key: str, identifier: str):
         message = f"Multiple task assets found with {compute_task_key=} and {identifier=}"
         super().__init__(compute_task_key=compute_task_key, identifier=identifier, message=message)
+
+
+class FutureError(Exception):
+    """Error while waiting a blocking operation to complete"""
+
+
+class FutureTimeoutError(FutureError):
+    """Future execution timed out."""
+
+
+class FutureFailureError(FutureError):
+    """Future execution failed."""

--- a/tests/sdk/test_wait.py
+++ b/tests/sdk/test_wait.py
@@ -6,8 +6,9 @@ from substra.sdk import exceptions
 from substra.sdk.models import ComputePlanStatus
 from substra.sdk.models import Status
 from substra.sdk.models import TaskErrorType
-from substra.test import datastore
-from substra.test.utils import mock_requests
+
+from .. import datastore
+from ..utils import mock_requests
 
 
 def _param_name_maker(arg):

--- a/tests/sdk/test_wait.py
+++ b/tests/sdk/test_wait.py
@@ -1,0 +1,71 @@
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from substra.sdk import exceptions
+from substra.sdk.models import ComputePlanStatus
+from substra.sdk.models import Status
+from substra.sdk.models import TaskErrorType
+from substra.test import datastore
+from substra.test.utils import mock_requests
+
+
+def _param_name_maker(arg):
+    if isinstance(arg, str):
+        return arg
+    else:
+        return ""
+
+
+@pytest.mark.parametrize(
+    ("asset_dict", "function_name", "status", "expectation"),
+    [
+        (datastore.TRAINTASK, "wait_task", Status.done, does_not_raise()),
+        (datastore.TRAINTASK, "wait_task", Status.canceled, pytest.raises(exceptions.FutureFailureError)),
+        (datastore.COMPUTE_PLAN, "wait_compute_plan", ComputePlanStatus.done, does_not_raise()),
+        (
+            datastore.COMPUTE_PLAN,
+            "wait_compute_plan",
+            ComputePlanStatus.failed,
+            pytest.raises(exceptions.FutureFailureError),
+        ),
+        (
+            datastore.COMPUTE_PLAN,
+            "wait_compute_plan",
+            ComputePlanStatus.canceled,
+            pytest.raises(exceptions.FutureFailureError),
+        ),
+    ],
+    ids=_param_name_maker,
+)
+def test_wait(client, mocker, asset_dict, function_name, status, expectation):
+    item = {**asset_dict, "status": status}
+    mock_requests(mocker, "get", item)
+    function = getattr(client, function_name)
+    with expectation:
+        function(key=item["key"])
+
+
+def test_wait_task_failed(client, mocker):
+    # We need an error type to stop the iteration
+    item = {**datastore.TRAINTASK, "status": Status.failed, "error_type": TaskErrorType.internal}
+    mock_requests(mocker, "get", item)
+    with pytest.raises(exceptions.FutureFailureError):
+        client.wait_task(key=item["key"])
+
+
+@pytest.mark.parametrize(
+    ("asset_dict", "function_name", "status"),
+    [
+        (datastore.TRAINTASK, "wait_task", Status.todo),
+        (datastore.COMPUTE_PLAN, "wait_compute_plan", ComputePlanStatus.todo),
+    ],
+    ids=_param_name_maker,
+)
+def test_wait_timeout(client, mocker, asset_dict, function_name, status):
+    item = {**asset_dict, "status": status}
+    mock_requests(mocker, "get", item)
+    function = getattr(client, function_name)
+    with pytest.raises(exceptions.FutureTimeoutError):
+        # mock_requests returns only once and timeout=0 is falsy, so setting a microscopic duration
+        function(key=item["key"], timeout=1e-10)


### PR DESCRIPTION
## Related issue

- https://github.com/Substra/substra/pull/368
- https://github.com/Substra/substrafl/pull/147
- https://github.com/Substra/substra-tests/pull/263
- https://github.com/Substra/substra-documentation/pull/327

## Summary

Centralize `wait_task` and `wait_compute_plan`, and re-use the implementation added in `substra` through the other components.

## Notes

Fixes FL-1052

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [x] [substra-tests](https://github.com/Substra/substra)
  - [x] [substrafl](https://github.com/Substra/substrafl)
  - [x] [substra-documentation](https://github.com/Substra/substra-documentation)
