### PR TITLE
feat: allow config file by env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `wait_task` and `wait_compute_plan` to block execution until execution is over ([#368](https://github.com/Substra/substra/pull/368))
-- Configuration file path can be set with env var `SUBSTRA_CLIENT_CONFIGURATION_FILE_PATH` ([#370](https://github.com/Substra/substra/pull/370))
+- Configuration file path can be set with env var `SUBSTRA_CLIENTS_CONFIGURATION_FILE_PATH` ([#370](https://github.com/Substra/substra/pull/370))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `wait_task` and `wait_compute_plan` to block execution until execution is over ([#368](https://github.com/Substra/substra/pull/368))
+- Configuration file path can be set with env var `SUBSTRA_CLIENT_CONFIGURATION_FILE_PATH` ([#370](https://github.com/Substra/substra/pull/370))
 
 ### Changed
 

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -235,7 +235,10 @@ class Client:
     ):
         # The value "" (which is Falsy) is used to bypass configuration file
         if configuration_file is None:
-            configuration_file = os.getenv("SUBSTRA_CLIENT_CONFIGURATION_FILE_PATH")
+            configuration_file = os.getenv("SUBSTRA_CLIENTS_CONFIGURATION_FILE_PATH")
+
+            if configuration_file:
+                logger.info("Getting configuration file path from env var SUBSTRA_CLIENTS_CONFIGURATION_FILE_PATH")
 
         if configuration_file and not client_name:
             raise exceptions.ConfigurationInfoError(

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -233,10 +233,17 @@ class Client:
         insecure: Optional[bool] = None,
         backend_type: Optional[schemas.BackendType] = None,
     ):
+        # The value "" (which is Falsy) is used to bypass configuration file
+        if configuration_file is None:
+            configuration_file = os.getenv("SUBSTRA_CLIENT_CONFIGURATION_FILE_PATH")
+
         if configuration_file and not client_name:
             raise exceptions.ConfigurationInfoError(
                 "Configuration file cannot be used because no `client_name` was given."
             )
+
+        if configuration_file:
+            configuration_file = pathlib.Path(configuration_file)
 
         code_values = {
             "url": url,

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -238,7 +238,10 @@ class Client:
             configuration_file = os.getenv("SUBSTRA_CLIENTS_CONFIGURATION_FILE_PATH")
 
             if configuration_file:
-                logger.info("Getting configuration file path from env var SUBSTRA_CLIENTS_CONFIGURATION_FILE_PATH")
+                logger.info(
+                    "Configuration file path set from env var SUBSTRA_CLIENTS_CONFIGURATION_FILE_PATH: "
+                    f"'{configuration_file}'"
+                )
 
         if configuration_file and not client_name:
             raise exceptions.ConfigurationInfoError(

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -206,7 +206,7 @@ def test_client_configuration_configuration_file_path_from_env_var(mocker, monke
     The configuration file path can be set through an env var
     """
     mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
-    monkeypatch.setenv("SUBSTRA_CLIENT_CONFIGURATION_FILE_PATH", config_file)
+    monkeypatch.setenv("SUBSTRA_CLIENTS_CONFIGURATION_FILE_PATH", config_file)
     client = Client(client_name="toto")
     assert client.backend_mode == "remote"
     assert client._url == "toto-org.com"
@@ -222,7 +222,7 @@ def test_client_configuration_configuration_file_path_parameter_supercedes_env_v
     The configuration file path env var is supercedes by `configuration_file=`
     """
     mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
-    monkeypatch.setenv("SUBSTRA_CLIENT_CONFIGURATION_FILE_PATH", config_file)
+    monkeypatch.setenv("SUBSTRA_CLIENTS_CONFIGURATION_FILE_PATH", config_file)
 
     config_2_dict = {
         "toto": {
@@ -241,7 +241,7 @@ def test_client_configuration_file_path_env_var_empty_string(mocker, monkeypatch
     The configuration file path env var is supercedes by `configuration_file=`
     """
     mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
-    monkeypatch.setenv("SUBSTRA_CLIENT_CONFIGURATION_FILE_PATH", config_file)
+    monkeypatch.setenv("SUBSTRA_CLIENTS_CONFIGURATION_FILE_PATH", config_file)
 
     client = Client(configuration_file="", client_name="toto")
     assert client.backend_mode == "subprocess"

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -238,7 +238,7 @@ def test_client_configuration_configuration_file_path_parameter_supercedes_env_v
 
 def test_client_configuration_file_path_env_var_empty_string(mocker, monkeypatch, config_file):
     """
-    The configuration file path env var is supercedes by `cconfiguration_file=`
+    The configuration file path env var is supercedes by `configuration_file=`
     """
     mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
     monkeypatch.setenv("SUBSTRA_CLIENT_CONFIGURATION_FILE_PATH", config_file)


### PR DESCRIPTION
## Summary

Allow to set-up configuration file path with `SUBSTRA_CLIENTS_CONFIGURATION_FILE_PATH`

## Notes

Fixes FL-1063

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
