### PR TITLE
fix: pin `pydantic` to `>=1.9.0` & `<2.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove `model` and `models` for input and output identifiers in tests. Replace by `shared` instead. ([#367](https://github.com/Substra/substra/pull/367))
 
+### Fixed
+
+- Pin `pydantic` to `>=1.9.0` & `<2.0.0` as `pydantic` v `2.0.0` has been released with a lot of non backward compatible changes. ([#371](https://github.com/Substra/substra/pull/371))
+
 ## [0.45.0](https://github.com/Substra/substra/releases/tag/0.45.0) - 2023-06-12
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "urllib3<2",
         "docker",
         "pyyaml",
-        "pydantic>=1.5.1",
+        "pydantic>=1.9.0, <2.0.0",
         "tqdm",
         "python-slugify",
     ],


### PR DESCRIPTION
## Related issue

- https://github.com/Substra/substrafl/pull/148

## Summary

Pin `pydantic` to `>=1.9.0` & `<2.0.0` as `pydantic` v `2.0.0` has been released with a lot of non backward compatible changes.

## Notes

Fixes FL-1070

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
