### PR TITLE
fix: remove pagination on `<task_id>/perf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove `model` and `models` for input and output identifiers in tests. Replace by `shared` instead. ([#367](https://github.com/Substra/substra/pull/367))
+- Remove pagination on `get_performances` to remove limitation on 1000 first points ([#372](https://github.com/Substra/substra/pull/372))
 
 ### Fixed
 

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -78,8 +78,8 @@ class Remote(base.BaseBackend):
         """Get an compute plan performance by key."""
 
         compute_plan = self.get(schemas.Type.ComputePlan, key)
-        results = self._client.list(schemas.Type.ComputePlan.to_server(), path=key + "/perf", paginated=True)
-
+        response = self._client.list(schemas.Type.ComputePlan.to_server(), path=key + "/perf", paginated=False)
+        results = response["results"]
         performances = models.Performances()
 
         for test_task in results:

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -593,9 +593,6 @@ COMPUTE_PLAN = {
 }
 
 COMPUTE_PLAN_PERF = {
-    "count": 3,
-    "previous": None,
-    "next": None,
     "results": [
         {
             "compute_task": {

--- a/tests/sdk/test_get.py
+++ b/tests/sdk/test_get.py
@@ -131,5 +131,5 @@ def test_get_performances(client, mocker):
 
     df = pd.DataFrame(response.dict())
     assert list(df.columns) == list(response.dict().keys())
-    assert df.shape[0] == perf_item["count"]
+    assert df.shape[0] == len(response.dict())
     assert m.call_count == 2

--- a/tests/sdk/test_get.py
+++ b/tests/sdk/test_get.py
@@ -128,8 +128,9 @@ def test_get_performances(client, mocker):
     m = mock_requests_responses(mocker, "get", [mock_response(cp_item), mock_response(perf_item)])
 
     response = client.get_performances("magic-key")
+    results = response.dict()
 
-    df = pd.DataFrame(response.dict())
-    assert list(df.columns) == list(response.dict().keys())
-    assert df.shape[0] == len(response.dict())
+    df = pd.DataFrame(results)
+    assert list(df.columns) == list(results.keys())
+    assert all(len(v) == df.shape[0] for v in results.values())
     assert m.call_count == 2


### PR DESCRIPTION
## Related issue

- https://github.com/Substra/substra-backend/pull/690
- https://github.com/Substra/substra-frontend/pull/222

## Summary

Remove pagination in performance endpoints, as we always need all of them. 

Note: alternative implementation would be to iterate on all pages in `<task_id>/perf/` in all case,  in the frontend and in the SDK.

## Notes

Fixes FL-1092

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
