### PR TITLE
chore: look for "detail" instead of "message" in API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wait_completion` param on `get_performances`, `list_task_output_assets` and `get_task_output_asset` to block execution until execution is over ([#368](https://github.com/Substra/substra/pull/368))
 - `list_task_output_assets` and `get_task_output_asset` wait that the compute task is over before getting assets ([#369](https://github.com/Substra/substra/pull/369))
 
+### Changed
+
+- change how API responses are parsed to match server changes ([#379](https://github.com/Substra/substra/pull/379))
+
 ### Fixed
 
 - typo in exception ([#377](https://github.com/Substra/substra/pull/377))

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -16,7 +16,7 @@ class RequestException(SDKException):
     def from_request_exception(cls, request_exception):
         msg = None
         try:
-            msg = request_exception.response.json()["message"]
+            msg = request_exception.response.json()["detail"]
             msg = f"{request_exception}: {msg}"
         except Exception:
             msg = str(request_exception)
@@ -63,7 +63,7 @@ class InvalidRequest(HTTPError):
 
         get_method = getattr(error, "get", None)
         if callable(get_method):
-            msg = get_method("message", str(error))
+            msg = get_method("detail", str(error))
         else:
             msg = str(error)
 
@@ -91,7 +91,7 @@ class RequestTimeout(HTTPError):
         r = request_exception.response.json()
 
         try:
-            key = r["key"] if "key" in r else r["message"].get("key")
+            key = r["key"] if "key" in r else r["detail"].get("key")
         except (AttributeError, KeyError):
             # XXX this is the case when doing a POST query to update the
             #     data manager for instance
@@ -197,7 +197,7 @@ class KeyAlreadyExistsError(Exception):
 
 
 class _TaskAssetError(Exception):
-    """Base eception class for task asset error"""
+    """Base exception class for task asset error"""
 
     def __init__(self, *, compute_task_key: str, identifier: str, message: str):
         self.compute_task_key = compute_task_key

--- a/tests/sdk/test_rest_client.py
+++ b/tests/sdk/test_rest_client.py
@@ -48,10 +48,10 @@ def test_post_success(mocker, config):
 @pytest.mark.parametrize(
     "status_code, http_response, sdk_exception",
     [
-        (400, {"message": "Invalid Request"}, exceptions.InvalidRequest),
-        (401, {"message": "Invalid username/password"}, exceptions.AuthenticationError),
-        (403, {"message": "Unauthorized"}, exceptions.AuthorizationError),
-        (404, {"message": "Not Found"}, exceptions.NotFound),
+        (400, {"detail": "Invalid Request"}, exceptions.InvalidRequest),
+        (401, {"detail": "Invalid username/password"}, exceptions.AuthenticationError),
+        (403, {"detail": "Unauthorized"}, exceptions.AuthorizationError),
+        (404, {"detail": "Not Found"}, exceptions.NotFound),
         (408, {"key": "a-key"}, exceptions.RequestTimeout),
         (408, {}, exceptions.RequestTimeout),
         (500, "CRASH", exceptions.InternalServerError),


### PR DESCRIPTION
Companion PR to https://github.com/Substra/substra-backend/pull/705



## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
