### PR TITLE
feat: add Client.logout and context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `list_task_output_assets` and `get_task_output_asset` wait that the compute task is over before getting assets ([#369](https://github.com/Substra/substra/pull/369))
 - warning and help message when logging in with username/password rather than token ([#378](https://github.com/Substra/substra/pull/378))
 - new `Client.logout` function, mirroring `Client.login` ([#381](https://github.com/Substra/substra/pull/381))
-- `Client` can now be the expression in a `with` statement ([#381](https://github.com/Substra/substra/pull/381))
+- `Client` can now be used within a context manager ([#381](https://github.com/Substra/substra/pull/381))
+  ```python
+  with Client(
+      client_name="org-1",
+      backend_type="remote",
+      url="http://substra-backend.org-1.com:8000",
+      username="org-1",
+      password="p@sswr0d44",
+  ) as client:
+      pass
+  ```
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wait_completion` param on `get_performances`, `list_task_output_assets` and `get_task_output_asset` to block execution until execution is over ([#368](https://github.com/Substra/substra/pull/368))
 - `list_task_output_assets` and `get_task_output_asset` wait that the compute task is over before getting assets ([#369](https://github.com/Substra/substra/pull/369))
 - warning and help message when logging in with username/password rather than token ([#378](https://github.com/Substra/substra/pull/378))
+- new `Client.logout` function, mirrorring `Client.login` ([#381](https://github.com/Substra/substra/pull/381))
+- `Client` can now be the expression in a `with` statement ([#381](https://github.com/Substra/substra/pull/381))
 
 ### Changed
 
 - change how API responses are parsed to match server changes ([#379](https://github.com/Substra/substra/pull/379))
+- `Client` will now terminate the sessions it starts when given username & password ([#381](https://github.com/Substra/substra/pull/381))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wait_completion` param on `get_performances`, `list_task_output_assets` and `get_task_output_asset` to block execution until execution is over ([#368](https://github.com/Substra/substra/pull/368))
 - `list_task_output_assets` and `get_task_output_asset` wait that the compute task is over before getting assets ([#369](https://github.com/Substra/substra/pull/369))
 - warning and help message when logging in with username/password rather than token ([#378](https://github.com/Substra/substra/pull/378))
-- new `Client.logout` function, mirrorring `Client.login` ([#381](https://github.com/Substra/substra/pull/381))
+- new `Client.logout` function, mirroring `Client.login` ([#381](https://github.com/Substra/substra/pull/381))
 - `Client` can now be the expression in a `with` statement ([#381](https://github.com/Substra/substra/pull/381))
 
 ### Changed

--- a/substra/sdk/backends/base.py
+++ b/substra/sdk/backends/base.py
@@ -15,6 +15,10 @@ class BaseBackend(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def logout(self):
+        pass
+
+    @abc.abstractmethod
     def get(self, asset_type, key):
         raise NotImplementedError
 

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -74,6 +74,9 @@ class Local(base.BaseBackend):
     def login(self, username, password):
         self._db.login(username, password)
 
+    def logout(self):
+        self._db.logout()
+
     def get(self, asset_type, key):
         return self._db.get(asset_type, key)
 

--- a/substra/sdk/backends/local/dal.py
+++ b/substra/sdk/backends/local/dal.py
@@ -53,6 +53,10 @@ class DataAccess:
         if self._remote:
             self._remote.login(username, password)
 
+    def logout(self):
+        if self._remote:
+            self._remote.logout()
+
     def add(self, asset):
         return self._db.add(asset)
 

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -42,6 +42,9 @@ class Remote(base.BaseBackend):
     def login(self, username, password):
         return self._client.login(username, password)
 
+    def logout(self):
+        return self._client.logout()
+
     def get(self, asset_type, key):
         """Get an asset by key."""
         asset = self._client.get(asset_type.to_server(), key)

--- a/substra/sdk/backends/remote/rest_client.py
+++ b/substra/sdk/backends/remote/rest_client.py
@@ -112,13 +112,13 @@ class Client:
 
     def logout(self) -> None:
         if not self._token_id:
-            logger.debug("Logging out has no effect (did not call Client.login)")
             return
         try:
             r = requests.delete(
                 f"{self._base_url}/active-api-tokens/", params={"id": self._token_id}, headers=self._headers
             )
             r.raise_for_status()
+            self._token_id = None
             logger.info("Successfully logged out")
         except requests.exceptions.ConnectionError as e:
             raise exceptions.ConnectionError.from_request_exception(e)

--- a/substra/sdk/backends/remote/rest_client.py
+++ b/substra/sdk/backends/remote/rest_client.py
@@ -111,7 +111,7 @@ class Client:
         return token
 
     def logout(self) -> None:
-        if not self._token_id:
+        if self._token_id is None:
             return
         try:
             r = requests.delete(

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -199,6 +199,12 @@ class Client:
             Defaults to None.
         username (str, optional): Username to authenticate to the Substra platform.
             Used in conjunction with a password to generate a token if not given, using the `login` function.
+
+            If using username/password, you should use a context manager to ensure the session is terminated:
+            ```
+            with Client(username, password) as client:
+               ...
+            ```
             Not stored.
             Defaults to None.
         password (str, optional): Password to authenticate to the Substra platform.

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -387,6 +387,7 @@ class Client:
         if not self._backend:
             raise exceptions.SDKException("No backend found")
         self._backend.logout()
+        self._token = None
 
     @staticmethod
     def _get_spec(asset_type, data):

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -386,8 +386,7 @@ class Client:
         """
         if not self._backend:
             raise exceptions.SDKException("No backend found")
-        if hasattr(self._backend, "logout"):
-            self._backend.logout()
+        self._backend.logout()
 
     @staticmethod
     def _get_spec(asset_type, data):

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -200,7 +200,7 @@ class Client:
         username (str, optional): Username to authenticate to the Substra platform.
             Used in conjunction with a password to generate a token if not given, using the `login` function.
 
-            If using username/password, you should use a context manager to ensure the session is terminated:
+            If using username/password, you should use a context manager to ensure the session terminates as intended:
             ```
             with Client(username, password) as client:
                ...

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -311,6 +311,14 @@ class Client:
             )
             self._token = self.login(config_dict["username"].value, config_dict["password"].value)
 
+    def __enter__(self):
+        # for use in a `with` statement
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # for use in a `with` statement
+        self.logout()
+
     def _get_backend(self, backend_type: schemas.BackendType):
         # Three possibilities:
         # - remote: get a remote backend
@@ -368,6 +376,16 @@ class Client:
             raise exceptions.SDKException("No backend found")
         self._token = self._backend.login(username, password)
         return self._token
+
+    @logit
+    def logout(self) -> None:
+        """
+        Log out from a remote server, if Client.login was used
+        """
+        if not self._backend:
+            raise exceptions.SDKException("No backend found")
+        if hasattr(self._backend, "logout"):
+            self._backend.logout()
 
     @staticmethod
     def _get_spec(asset_type, data):

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -312,11 +312,12 @@ class Client:
             self._token = self.login(config_dict["username"].value, config_dict["password"].value)
 
     def __enter__(self):
-        # for use in a `with` statement
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        # for use in a `with` statement
+        self.logout()
+
+    def __del__(self):
         self.logout()
 
     def _get_backend(self, backend_type: schemas.BackendType):
@@ -381,6 +382,7 @@ class Client:
     def logout(self) -> None:
         """
         Log out from a remote server, if Client.login was used
+        (otherwise, nothing happens)
         """
         if not self._backend:
             raise exceptions.SDKException("No backend found")


### PR DESCRIPTION
## Summary

Add a `Client.logout` function, which deletes a token obtained by `Client.login` (if any).

Add a context manager, making the following snippet legal:

```python
with Client(
    client_name="org-1",
    backend_type="remote",
    url="http://substra-backend.org-1.com:8000",
    username="org-1",
    password="p@sswr0d44",
) as client:
    pass
```

Requires https://github.com/Substra/substra-backend/pull/698

Closes FL-1008

## Notes

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
