### PR TITLE
fix: prevent Client.logout from raising exceptions

### DIFF
--- a/substra/sdk/backends/remote/rest_client.py
+++ b/substra/sdk/backends/remote/rest_client.py
@@ -115,8 +115,15 @@ class Client:
             r.raise_for_status()
             self._token = None
             logger.info("Successfully logged out")
-        except requests.exceptions.HTTPError as e:
-            logger.error(f"Could not end session {self._token['id']}, got {e.response.status_code}: {e.response.text}")
+        except requests.exceptions.RequestException as e:
+            logger.error(
+                f"Could not end session {self._token['id']}"
+                + (
+                    f", got {e.response.status_code}: {e.response.text}"
+                    if isinstance(e, requests.exceptions.HTTPError)
+                    else f": {e}"
+                )
+            )
             _warn_of_session_expiration(self._token["expires_at"], minimum_log_level=logging.WARNING)
             # this isn't too much of an issue, the token will expire on its own
 

--- a/substra/sdk/backends/remote/rest_client.py
+++ b/substra/sdk/backends/remote/rest_client.py
@@ -120,12 +120,9 @@ class Client:
             r.raise_for_status()
             self._token_id = None
             logger.info("Successfully logged out")
-        except requests.exceptions.ConnectionError as e:
-            raise exceptions.ConnectionError.from_request_exception(e)
-        except requests.exceptions.Timeout as e:
-            raise exceptions.Timeout.from_request_exception(e)
         except requests.exceptions.HTTPError as e:
-            raise exceptions.HTTPError.from_request_exception(e)
+            logger.error(f"Could not end session {self._token_id}, got {e.response.status_code}: {e.response.text}")
+            # this isn't too much of an issue, the token will expire on its own
 
     # TODO: '__request' is too complex, consider refactoring
     def __request(self, request_name, url, **request_kwargs):  # noqa: C901


### PR DESCRIPTION
`Client.logout` is called in `__del__` and raising exceptions there is discouraged, therefore this PR removes that.

See Sarah's comment: https://github.com/Substra/substra/pull/381#discussion_r1297021646

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
