### PR TITLE
fix: make Client(insecure=True) affect login & logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - typo in exception ([#377](https://github.com/Substra/substra/pull/377))
+- Client.login breaking when Client was instanciated with `insecure=True` ([#384](https://github.com/Substra/substra/pull/384))
 
 ## [0.46.0](https://github.com/Substra/substra/releases/tag/0.46.0) - 2023-07-25
 

--- a/substra/sdk/backends/remote/rest_client.py
+++ b/substra/sdk/backends/remote/rest_client.py
@@ -68,7 +68,7 @@ class Client:
             "password": password,
         }
         try:
-            r = requests.post(f"{self._base_url}/api-token-auth/", data=data, headers=headers)
+            r = requests.post(f"{self._base_url}/api-token-auth/", data=data, headers=headers, **self._default_kwargs)
             r.raise_for_status()
         except requests.exceptions.RequestException as e:
             if isinstance(e, requests.exceptions.HTTPError):
@@ -110,7 +110,10 @@ class Client:
             return
         try:
             r = requests.delete(
-                f"{self._base_url}/active-api-tokens/", params={"id": self._token["id"]}, headers=self._headers
+                f"{self._base_url}/active-api-tokens/",
+                params={"id": self._token["id"]},
+                headers=self._headers,
+                **self._default_kwargs,
             )
             r.raise_for_status()
             self._token = None

--- a/tests/sdk/test_rest_client.py
+++ b/tests/sdk/test_rest_client.py
@@ -45,6 +45,25 @@ def test_post_success(mocker, config):
     assert len(m.call_args_list) == 1
 
 
+@pytest.mark.parametrize("config", CONFIGS)
+def test_verify_login(mocker, config):
+    """
+    check "insecure" configuration results in endpoints being called with verify=False
+    """
+    m_post = mock_requests(mocker, "post", response={"id": "a", "token": "a", "expires_at": "3000-01-01T00:00:00Z"})
+    m_delete = mock_requests(mocker, "delete", response={})
+
+    c = _client_from_config(config)
+    c.login("foo", "bar")
+    c.logout()
+    if config.get("insecure", None):
+        assert m_post.call_args.kwargs["verify"] == False
+        assert m_delete.call_args.kwargs["verify"] == False
+    else:
+        assert "verify" not in m_post.call_args.kwargs or m_post.call_args.kwargs["verify"]
+        assert "verify" not in m_post.call_args.kwargs or m_delete.call_args.kwargs["verify"]
+
+
 @pytest.mark.parametrize(
     "status_code, http_response, sdk_exception",
     [


### PR DESCRIPTION
## Summary

Currently instantiating a Client with `insecure=True` (which disables SSL verification) will still fail you at login if you have an invalid TLS certificate. This fixes that.

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
