### PR TITLE
feat: update download_logs url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: Renamed `function` field of the Function pydantic model to `archive`([#393](https://github.com/Substra/substra/pull/393))
 - BREAKING: Renamed ComputeTask status ([#397](https://github.com/Substra/substra/pull/397))
+- `download_logs` uses the new endpoint ([#398](https://github.com/Substra/substra/pull/398))
 
 ### Added
 

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -325,7 +325,7 @@ class Remote(base.BaseBackend):
         """Download the logs of a failed task. If destination_file is set, return the full
         destination path, otherwise, return the logs as a str.
         """
-        url = f"{self._client.base_url}/logs/{task_key}/file/"
+        url = f"{self._client.base_url}/task/{task_key}/logs/"
 
         if destination_file:
             return self._download(url, destination_file)


### PR DESCRIPTION
## Related issue
Companion PR https://github.com/Substra/substra-backend/pull/824

## Summary

## Notes

Fixes FL-1285

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
