### PR TITLE
chore: bump actions using node 16 to node 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,9 +11,9 @@ jobs:
     name: Lint and documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install tools
@@ -49,7 +49,7 @@ jobs:
     name: Tests on Python ${{ matrix.python-version }}
     steps:
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -63,11 +63,11 @@ jobs:
           export PATH=/home/runner/bin:$PATH
           /home/runner/bin/dockerd-rootless.sh &  # Start Docker rootless in the background
       - name: Cloning substra
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: substra
       - name: Cloning substratools
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Substra/substra-tools
           path: substratools

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -92,6 +92,7 @@ def test_client_should_raise_when_missing_name():
 def test_client_with_password(mocker):
     mocker.patch("substra.sdk.Client.login", side_effect=stub_login)
     rest_client_logout = mocker.patch("substra.sdk.backends.remote.rest_client.Client.logout")
+    rest_client_logout.reset_mock()
     client_args = {
         "backend_type": "remote",
         "url": "example.com",


### PR DESCRIPTION
## Related issue

`#` followed by the number of the issue

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
