### PR TITLE
chore: descritpion.md are now optional

### DIFF
--- a/changes/417.changed
+++ b/changes/417.changed
@@ -1,0 +1,1 @@
+`description.md` are now `Optional` in `DatasampleSpec`. If none is given, `Ssubtra` will generate a template indicating how to add a custom description file on dataset registration.

--- a/changes/417.changed
+++ b/changes/417.changed
@@ -1,1 +1,1 @@
-`description.md` are now `Optional` in `DatasampleSpec`. If none is given, `Ssubtra` will generate a template indicating how to add a custom description file on dataset registration.
+`description.md` are now `Optional` in `DatasampleSpec`. If no description file is given, `Substra` will generate a template indicating how to add a custom description file during dataset registration.

--- a/references/sdk_schemas.md
+++ b/references/sdk_schemas.md
@@ -33,10 +33,11 @@ the 'paths' field.
 Specification for creating a dataset
 
 note : metadata field does not accept strings containing '__' as dict key
+note : If no description markdown file is given, create an empty one on the data_opener folder.
 ```text
 - name: <class 'str'>
 - data_opener: <class 'pathlib.Path'>
-- description: <class 'pathlib.Path'>
+- description: typing.Optional[pathlib.Path]
 - permissions: <class 'substra.sdk.schemas.Permissions'>
 - metadata: typing.Optional[typing.Dict[str, str]]
 - logs_permission: <class 'substra.sdk.schemas.Permissions'>

--- a/references/sdk_schemas.md
+++ b/references/sdk_schemas.md
@@ -33,6 +33,7 @@ the 'paths' field.
 Specification for creating a dataset
 
 note : metadata field does not accept strings containing '__' as dict key
+
 note : If no description markdown file is given, create an empty one on the data_opener folder.
 ```text
 - name: <class 'str'>

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -2,6 +2,7 @@ import contextlib
 import enum
 import json
 import pathlib
+import tempfile
 import typing
 import uuid
 from typing import Dict
@@ -18,6 +19,13 @@ _SERVER_NAMES = {
     "dataset": "data_manager",
     "summary_task": "task",
 }
+
+GENERATED_DESCRIPTION_CONTENT = """
+# No description given
+
+To add a dataset description, create a markdown file and pass it to your
+`substra.sdk.schemasDatasetSpec` on your dataset opener registration.
+"""
 
 
 class BackendType(str, enum.Enum):
@@ -282,12 +290,23 @@ class DatasetSpec(_Spec):
 
     name: str
     data_opener: pathlib.Path  # Path to the data opener
-    description: pathlib.Path  # Path to the description file
+    description: Optional[pathlib.Path] = None  # Path to the description file
     permissions: Permissions
     metadata: Optional[Dict[str, str]] = None
     logs_permission: Permissions
 
     type_: typing.ClassVar[Type] = Type.Dataset
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _check_description(cls, values):
+        if "description" not in values:
+            parent_path = pathlib.Path(values["data_opener"]).parent
+            description_path = parent_path / "generated_description.md"
+            with description_path.open("w", encoding="utf-8") as f:
+                f.write(GENERATED_DESCRIPTION_CONTENT)
+            values["description"] = description_path
+        return values
 
     class Meta:
         file_attributes = (

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -286,6 +286,7 @@ class DatasetSpec(_Spec):
     """Specification for creating a dataset
 
     note : metadata field does not accept strings containing '__' as dict key
+
     note : If no description markdown file is given, create an empty one on the data_opener folder.
     """
 

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -2,7 +2,6 @@ import contextlib
 import enum
 import json
 import pathlib
-import tempfile
 import typing
 import uuid
 from typing import Dict

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -286,11 +286,12 @@ class DatasetSpec(_Spec):
     """Specification for creating a dataset
 
     note : metadata field does not accept strings containing '__' as dict key
+    note : If no description markdown file is given, create an empty one on the data_opener folder.
     """
 
     name: str
     data_opener: pathlib.Path  # Path to the data opener
-    description: Optional[pathlib.Path] = None  # Path to the description file
+    description: Optional[pathlib.Path] = None  # Path to the description file.
     permissions: Permissions
     metadata: Optional[Dict[str, str]] = None
     logs_permission: Permissions

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -23,7 +23,7 @@ GENERATED_DESCRIPTION_CONTENT = """
 # No description given
 
 To add a dataset description, create a markdown file and pass it to your
-`substra.sdk.schemasDatasetSpec` on your dataset opener registration.
+`substra.sdk.schemas.DatasetSpec` on your dataset opener registration.
 """
 
 

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -291,7 +291,7 @@ class DatasetSpec(_Spec):
 
     name: str
     data_opener: pathlib.Path  # Path to the data opener
-    description: Optional[pathlib.Path] = None  # Path to the description file.
+    description: Optional[pathlib.Path] = None  # Path to the description file
     permissions: Permissions
     metadata: Optional[Dict[str, str]] = None
     logs_permission: Permissions

--- a/tests/sdk/test_schemas.py
+++ b/tests/sdk/test_schemas.py
@@ -45,9 +45,6 @@ def test_datasample_spec_path_set_to_none():
 def test_dataset_spec_no_description(tmpdir):
 
     opener_path = tmpdir / "fake_opener.py"
-    with open(opener_path, "w") as f:
-        f.write("print('I'm opening your data')")
-
     permissions = Permissions(public=True, authorized_ids=[])
 
     DatasetSpec(

--- a/tests/sdk/test_schemas.py
+++ b/tests/sdk/test_schemas.py
@@ -4,6 +4,8 @@ import uuid
 import pytest
 
 from substra.sdk.schemas import DataSampleSpec
+from substra.sdk.schemas import DatasetSpec
+from substra.sdk.schemas import Permissions
 
 
 @pytest.mark.parametrize("path", [pathlib.Path() / "data", "./data", pathlib.Path().cwd() / "data"])
@@ -38,3 +40,21 @@ def test_datasample_spec_paths_set_to_none():
 def test_datasample_spec_path_set_to_none():
     with pytest.raises(ValueError):
         DataSampleSpec(path=None, data_manager_keys=[str(uuid.uuid4())])
+
+
+def test_dataset_spec_no_description(tmpdir):
+
+    opener_path = tmpdir / "opener.py"
+    with open(opener_path, "w") as f:
+        f.write("print('I'm opening your data')")
+
+    permissions = Permissions(public=True, authorized_ids=[])
+
+    DatasetSpec(
+        name="Fake Dataset",
+        data_opener=str(opener_path),
+        permissions=permissions,
+        logs_permission=permissions,
+    )
+
+    assert (pathlib.Path(opener_path).parent / "generated_description.md").exists

--- a/tests/sdk/test_schemas.py
+++ b/tests/sdk/test_schemas.py
@@ -44,7 +44,7 @@ def test_datasample_spec_path_set_to_none():
 
 def test_dataset_spec_no_description(tmpdir):
 
-    opener_path = tmpdir / "opener.py"
+    opener_path = tmpdir / "fake_opener.py"
     with open(opener_path, "w") as f:
         f.write("print('I'm opening your data')")
 


### PR DESCRIPTION
## Related issue

closes FL-1513

## Summary

Create an "empty" description file if none given:

<img width="971" alt="image" src="https://github.com/Substra/substra/assets/50656860/1630153a-4963-4501-9f28-e33521b369f5">


## Notes

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
