### PR TITLE
fix(workflows/python): deprecated actions/upload-artifact@v2 

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,7 @@ jobs:
           python bin/generate_sdk_schemas_documentation.py --output-path references/sdk_schemas.md
           python bin/generate_sdk_schemas_documentation.py --models --output-path='references/sdk_models.md'
       - name: Documentation artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           retention-days: 1


### PR DESCRIPTION
## Related issue

https://github.com/Substra/substra/actions/runs/10825863599/job/30038921156

`#` followed by the number of the issue

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
- For any breaking changes, companion PRs have been opened on the following repositories:
  - [ ] [substra-tests](https://github.com/Substra/substra)
  - [ ] [substrafl](https://github.com/Substra/substrafl)
  - [ ] [substra-documentation](https://github.com/Substra/substra-documentation)
